### PR TITLE
Feature: Adding ID3 'Title' 'Artist' Column

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ set(libfm_SRCS
     filesearchdialog.cpp
     fm-search.c # might be moved to libfm later
     xdndworkaround.cpp
+    id3datamodel.cpp
 )
 
 set(libfm_UIS
@@ -87,6 +88,7 @@ add_library(${LIBFM_QT_LIBRARY_NAME} SHARED
     ${libfm_SRCS}
     ${libfm_UIS_H}
     ${QM_FILES}
+    /usr/lib64/libid3.so
 )
 
 set_property(
@@ -112,6 +114,7 @@ target_link_libraries(${LIBFM_QT_LIBRARY_NAME}
     ${LIBFM_LIBRARIES}
     ${LIBMENUCACHE_LIBRARIES}
     ${SYSTEM_LIBS_LIBRARIES}
+    /usr/lib64/libid3.so
 )
 
 # set libtool soname

--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -223,6 +223,18 @@ QVariant FolderModel::data(const QModelIndex & index, int role/* = Qt::DisplayRo
           const char* name = fm_file_info_get_disp_owner(info);
           return QString::fromUtf8(name);
         }
+        case ColumnFileID3Title: {
+          ID3DataModel id3Data (fm_path_to_str(fm_file_info_get_path(info)));
+          return QString::fromStdString(id3Data.parseData(ID3DataModel::ColumnFileID3Title));
+        }
+        case ColumnFileID3Artist: {
+          ID3DataModel id3Data (fm_path_to_str(fm_file_info_get_path(info)));
+          return QString::fromStdString(id3Data.parseData(ID3DataModel::ColumnFileID3Artist));
+        }
+        case ColumnFileID3Album: {
+          ID3DataModel id3Data (fm_path_to_str(fm_file_info_get_path(info)));
+          return QString::fromStdString(id3Data.parseData(ID3DataModel::ColumnFileID3Album));
+        }
       }
     }
     case Qt::DecorationRole: {
@@ -258,6 +270,12 @@ QVariant FolderModel::headerData(int section, Qt::Orientation orientation, int r
           break;
         case ColumnFileOwner:
           title = tr("Owner");
+          break;
+        case ColumnFileID3Title:
+          title = tr("Title");
+          break;
+        case ColumnFileID3Artist:
+          title = tr("Artist");
           break;
       }
       return QVariant(title);

--- a/src/foldermodel.h
+++ b/src/foldermodel.h
@@ -31,6 +31,7 @@
 #include <QLinkedList>
 #include <QPair>
 #include "foldermodelitem.h"
+#include "id3datamodel.h"
 
 namespace Fm {
 
@@ -48,6 +49,9 @@ public:
     ColumnFileSize,
     ColumnFileMTime,
     ColumnFileOwner,
+    ColumnFileID3Title,
+    ColumnFileID3Artist,
+    ColumnFileID3Album,
     NumOfColumns
   };
 

--- a/src/id3datamodel.cpp
+++ b/src/id3datamodel.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2012 - 2015  Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+#include "foldermodel.h"
+#include "id3datamodel.h"
+#include <codecvt>
+#include <string>
+
+namespace Fm {
+  ID3DataModel::ID3DataModel (const char* path) {
+    filePath = (char *)path;
+    acceptName = std::regex ("^.*(\.mp3)$");
+  }
+
+  std::string ID3DataModel::parseData (ColumnId type) {
+    if ( ! std::regex_match (filePath, acceptName)) {
+      return std::string("");
+    }
+
+    fileTag.Link (filePath, ID3TE_UTF8 | ID3TT_ALL);
+    switch (type) {
+      case ColumnFileID3Title: {
+        fileTagFrame = fileTag.Find (ID3FID_TITLE);
+        break;
+      }
+      case ColumnFileID3Artist: {
+        fileTagFrame = fileTag.Find (ID3FID_LEADARTIST);
+        break;
+      }
+      case ColumnFileID3Album: {
+        fileTagFrame = fileTag.Find (ID3FID_ALBUM);
+        break;
+      }
+    }
+    if (fileTagFrame) {
+      const char *tmp = fileTagFrame -> GetField(ID3FN_TEXT) -> GetRawText();
+      if (tmp) { return std::string(tmp); }
+      return std::string("");
+    } else {
+      return std::string("");
+    }
+  }
+
+  void ID3DataModel::setPath (const char* path) {
+    filePath = (char *)path;
+  }
+}

--- a/src/id3datamodel.h
+++ b/src/id3datamodel.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2012 - 2015  Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+#ifndef FM_ID3DATAMODEL_H
+#define FM_ID3DATAMODEL_H
+
+#include "libfmqtglobals.h"
+#include <QAbstractListModel>
+#include <QIcon>
+#include <QImage>
+#include <libfm/fm.h>
+#include <QList>
+#include <QVector>
+#include <QLinkedList>
+#include <QPair>
+#include "foldermodelitem.h"
+#include "foldermodel.h"
+#include <regex>
+#include <id3/tag.h>
+#include <id3/field.h>
+#include <cstring>
+
+namespace Fm {
+
+class LIBFM_QT_API ID3DataModel {
+public:
+  ID3DataModel (const char*);
+
+  enum ColumnId {
+    ColumnFileID3Title,
+    ColumnFileID3Artist,
+    ColumnFileID3Album
+  };
+
+  std::string parseData (enum ColumnId);
+
+  void setPath (const char*);
+
+protected:
+
+private:
+  char* filePath;
+  std::regex acceptName;
+  
+  ID3_Tag fileTag;
+  ID3_Frame* fileTagFrame;
+};
+
+}
+
+#endif // FM_ID3DATAMODEL_H

--- a/src/proxyfoldermodel.cpp
+++ b/src/proxyfoldermodel.cpp
@@ -20,6 +20,7 @@
 
 #include "proxyfoldermodel.h"
 #include "foldermodel.h"
+#include "id3datamodel.h"
 #include <QCollator>
 
 namespace Fm {
@@ -158,6 +159,12 @@ bool ProxyFolderModel::lessThan(const QModelIndex& left, const QModelIndex& righ
         // TODO: sort by owner
         break;
       case FolderModel::ColumnFileType:
+        break;
+      case FolderModel::ColumnFileID3Title: 
+        break;
+      case FolderModel::ColumnFileID3Artist:
+        break;
+      case FolderModel::ColumnFileID3Album:
         break;
     }
   }


### PR DESCRIPTION
*This is a testing feature, just wait for this able to work properly ,then be able to be accepted.

Since this is a file manager, I'd like to manage my music use pcmanfm, but I cannot view ID3Tag with this FM. Thus, I tried to make this feature come true. I use id3lib to perform ID3Tag reading, then add 2 testing column (Title, Artist) and finally show these tags. I'd like to get some opinions of this feature, since I've completed this code partly.

Known Issue:
1.Sort These column
2.CMake library including with libid3（I include library with absolute path, this is just a temporary solution.)
3.Acceleration of Reading Operation
4.ID3Tag Edit, Writing using filepropertydialog.
