### PR TITLE
Elided labels for file operation dialog

### DIFF
--- a/src/file-operation-dialog.ui
+++ b/src/file-operation-dialog.ui
@@ -34,7 +34,7 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="Fm::ElidedLable" name="dest">
+      <widget class="Fm::ElidedLabel" name="dest">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -57,7 +57,7 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="Fm::ElidedLable" name="curFile">
+      <widget class="Fm::ElidedLabel" name="curFile">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -149,7 +149,7 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Fm::ElidedLable</class>
+   <class>Fm::ElidedLabel</class>
    <extends>QLabel</extends>
    <header>fileoperationdialog_p.h</header>
   </customwidget>

--- a/src/file-operation-dialog.ui
+++ b/src/file-operation-dialog.ui
@@ -34,7 +34,7 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QLabel" name="dest">
+      <widget class="Fm::ElidedLable" name="dest">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -57,7 +57,7 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QLabel" name="curFile">
+      <widget class="Fm::ElidedLable" name="curFile">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -147,6 +147,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Fm::ElidedLable</class>
+   <extends>QLabel</extends>
+   <header>fileoperationdialog_p.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/src/fileoperationdialog_p.h
+++ b/src/fileoperationdialog_p.h
@@ -1,0 +1,69 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+
+#ifndef FM_FILEOPERATIONDIALOG_P_H
+#define FM_FILEOPERATIONDIALOG_P_H
+
+#include <QPainter>
+#include <QStyleOption>
+#include <QLabel>
+
+namespace Fm {
+
+class ElidedLable : public QLabel {
+Q_OBJECT
+
+public:
+    explicit ElidedLable(QWidget *parent = 0, Qt::WindowFlags f = Qt::WindowFlags()):
+        QLabel(parent, f),
+        lastWidth_(0) {
+            setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+            // set a min width to prevent the window from widening with long texts
+            setMinimumWidth(fontMetrics().averageCharWidth() * 10);
+        }
+
+protected:
+    // A simplified version of QLabel::paintEvent() without pixmap or shortcut but with eliding.
+    void paintEvent(QPaintEvent* /*event*/) override {
+        QRect cr = contentsRect().adjusted(margin(), margin(), -margin(), -margin());
+        QString txt = text();
+        // if the text is changed or its rect is resized (due to window resizing),
+        // find whether it needs to be elided...
+        if (txt != lastText_ || cr.width() != lastWidth_) {
+            lastText_ = txt;
+            lastWidth_ = cr.width();
+            elidedText_ = fontMetrics().elidedText(txt, Qt::ElideMiddle, cr.width());
+        }
+        // ... then, draw the (elided) text
+        if(!elidedText_.isEmpty()) {
+            QPainter painter(this);
+            QStyleOption opt;
+            opt.initFrom(this);
+            style()->drawItemText(&painter, cr, alignment(), opt.palette, isEnabled(), elidedText_, foregroundRole());
+        }
+    }
+
+private:
+    QString elidedText_;
+    QString lastText_;
+    int lastWidth_;
+};
+
+}
+
+#endif // FM_FILEOPERATIONDIALOG_P_H

--- a/src/fileoperationdialog_p.h
+++ b/src/fileoperationdialog_p.h
@@ -25,11 +25,11 @@
 
 namespace Fm {
 
-class ElidedLable : public QLabel {
+class ElidedLabel : public QLabel {
 Q_OBJECT
 
 public:
-    explicit ElidedLable(QWidget *parent = 0, Qt::WindowFlags f = Qt::WindowFlags()):
+    explicit ElidedLabel(QWidget *parent = 0, Qt::WindowFlags f = Qt::WindowFlags()):
         QLabel(parent, f),
         lastWidth_(0) {
             setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/578.

This prevents the dialog from widening when a file name/path is too long; the user could resize it at will.