### PR TITLE
Select multiple files

### DIFF
--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -85,6 +85,7 @@ void FolderModel::onFilesAdded(const Fm::FileInfoList& files) {
         items.append(item);
     }
     endInsertRows();
+    Q_EMIT filesAdded(files);
 }
 
 void FolderModel::onFilesChanged(std::vector<Fm::FileInfoPair>& files) {

--- a/src/foldermodel.h
+++ b/src/foldermodel.h
@@ -99,6 +99,7 @@ public:
 Q_SIGNALS:
     void thumbnailLoaded(const QModelIndex& index, int size);
     void fileSizeChanged(const QModelIndex& index);
+    void filesAdded(FileInfoList infoList);
 
 protected Q_SLOTS:
 

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -909,6 +909,43 @@ QModelIndex FolderView::indexFromFolderPath(const Fm::FilePath& folderPath) cons
     return QModelIndex();
 }
 
+void FolderView::selectFiles(const Fm::FileInfoList& files, bool add) {
+  if(!model_ || files.empty()) {
+      return;
+  }
+  if(!add) {
+      selectionModel()->clear();
+  }
+  QModelIndex index, firstIndex;
+  int count = model_->rowCount();
+  Fm::FileInfoList list = files;
+  bool singleFile(files.size() == 1);
+  for(int row = 0; row < count; ++row) {
+      if (list.empty()) {
+          break;
+      }
+      index = model_->index(row, 0);
+      auto info = model_->fileInfoFromIndex(index);
+      for(auto it = list.cbegin(); it != list.cend(); ++it) {
+          auto& item = *it;
+          if(item == info) {
+              selectionModel()->select(index, QItemSelectionModel::Select);
+              if (!firstIndex.isValid()) {
+                  firstIndex = index;
+              }
+              list.erase(it);
+              break;
+          }
+      }
+  }
+  if (firstIndex.isValid()) {
+      view->scrollTo(firstIndex, QAbstractItemView::EnsureVisible);
+      if (singleFile) { // give focus to the single file
+          selectionModel()->setCurrentIndex(firstIndex, QItemSelectionModel::Current);
+      }
+  }
+}
+
 Fm::FileInfoList FolderView::selectedFiles() const {
     if(model_) {
         QModelIndexList selIndexes = mode == DetailedListMode ? selectedRows() : selectedIndexes();

--- a/src/folderview.h
+++ b/src/folderview.h
@@ -102,6 +102,7 @@ public:
     Fm::FilePathList selectedFilePaths() const;
     bool hasSelection() const;
     QModelIndex indexFromFolderPath(const Fm::FilePath& folderPath) const;
+    void selectFiles(const Fm::FileInfoList& files, bool add = false);
 
     void selectAll();
 


### PR DESCRIPTION
This is for selecting multiple files as well as signalling file addition and will be followed by another patch for selecting newly created files in pcmanfm-qt but may be used for other purposes too.