### PR TITLE
Add kitty to terminals.list

### DIFF
--- a/data/terminals.list
+++ b/data/terminals.list
@@ -75,3 +75,6 @@ desktop_id=terminology.desktop
 open_arg=-e
 noclose_arg=--hold -e
 desktop_id=termite.desktop
+
+[kitty]
+desktop_id=kitty.desktop


### PR DESCRIPTION
No open argument needed, just `kitty vim` will start the application.