### PR TITLE
Fix crashes in new templates code

### DIFF
--- a/src/core/templates.h
+++ b/src/core/templates.h
@@ -92,7 +92,7 @@ private Q_SLOTS:
 private:
     std::vector<std::shared_ptr<TemplateItem>> items_;
     std::vector<std::shared_ptr<Folder>> templateFolders_;
-    static std::shared_ptr<Templates> globalInstance_;
+    static std::weak_ptr<Templates> globalInstance_;
 };
 
 } // namespace Fm


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/670

Two kinds of crashes are fixed:

(1) The right click crash as root; and
(2) The crash in `Fm::Folder::~Folder()` caused by `Templates::~Templates()`.