### PR TITLE
Delete CachedFolderModel immediately on unreffing it

### DIFF
--- a/src/cachedfoldermodel.cpp
+++ b/src/cachedfoldermodel.cpp
@@ -59,7 +59,7 @@ void CachedFolderModel::unref() {
     --refCount;
     if(refCount <= 0) {
         folder()->setProperty(cacheKey, QVariant());
-        deleteLater();
+        delete(this);
     }
 }
 

--- a/src/proxyfoldermodel.cpp
+++ b/src/proxyfoldermodel.cpp
@@ -115,18 +115,20 @@ void ProxyFolderModel::setSortCaseSensitivity(Qt::CaseSensitivity cs) {
 
 bool ProxyFolderModel::filterAcceptsRow(int source_row, const QModelIndex& source_parent) const {
     if(!showHidden_) {
-        FolderModel* srcModel = static_cast<FolderModel*>(sourceModel());
-        auto info = srcModel->fileInfoFromIndex(srcModel->index(source_row, 0, source_parent));
-        if(info && (info->isHidden() || (backupAsHidden_ && info->isBackup()))) {
-            return false;
+        if(FolderModel* srcModel = static_cast<FolderModel*>(sourceModel())) {
+            auto info = srcModel->fileInfoFromIndex(srcModel->index(source_row, 0, source_parent));
+            if(info && (info->isHidden() || (backupAsHidden_ && info->isBackup()))) {
+                return false;
+            }
         }
     }
     // apply additional filters if there're any
     for(ProxyFolderModelFilter* const filter : qAsConst(filters_)) {
-        FolderModel* srcModel = static_cast<FolderModel*>(sourceModel());
-        auto fileInfo = srcModel->fileInfoFromIndex(srcModel->index(source_row, 0, source_parent));
-        if(!filter->filterAcceptsRow(this, fileInfo)) {
-            return false;
+        if(FolderModel* srcModel = static_cast<FolderModel*>(sourceModel())){
+            auto fileInfo = srcModel->fileInfoFromIndex(srcModel->index(source_row, 0, source_parent));
+            if(!filter->filterAcceptsRow(this, fileInfo)) {
+                return false;
+            }
         }
     }
     return true;


### PR DESCRIPTION
Fixes https://github.com/lxqt/libfm-qt/issues/164

Previously, `deleteLater()` worked by chance but, with recent changes to `QSortFilterProxyModel::setSourceModel()` in Qt5.11, it can delete `CachedFolderModel` *after* changing directory (not really a Qt bug).

Also, logiclal nullity checks are added to `ProxyFolderModel`, although they may not be needed in practice.