### PR TITLE
Bump API & ABI versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,10 @@ project(libfm-qt)
 
 set(LIBFM_QT_LIBRARY_NAME "fm-qt" CACHE STRING "fm-qt")
 
-set(LIBFM_QT_VERSION_MAJOR 0)
-set(LIBFM_QT_VERSION_MINOR 13)
-set(LIBFM_QT_VERSION_PATCH 1)
-set(LIBFM_QT_VERSION ${LIBFM_QT_VERSION_MAJOR}.${LIBFM_QT_VERSION_MINOR}.${LIBFM_QT_VERSION_PATCH})
+set(LIBFM_QT_API_VERSION_MAJOR 0)
+set(LIBFM_QT_API_VERSION_MINOR 14)
+set(LIBFM_QT_API_VERSION_PATCH 0)
+set(LIBFM_QT_API_VERSION ${LIBFM_QT_API_VERSION_MAJOR}.${LIBFM_QT_API_VERSION_MINOR}.${LIBFM_QT_API_VERSION_PATCH})
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
@@ -17,9 +17,9 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 # Actually, libtool uses different ways on different operating systems. So there is no
 # universal way to translate a libtool version-info to a cmake version.
 # We use "(current-age).age.revision" as the cmake version.
-# current: 5, revision: 0, age: 0 => version: 5.0.0
-set(LIBFM_QT_LIB_VERSION "5.0.0")
-set(LIBFM_QT_LIB_SOVERSION "5")
+# current: 6, revision: 0, age: 0 => version: 6.0.0
+set(LIBFM_QT_ABI_VERSION "6.0.0")
+set(LIBFM_QT_SOVERSION "6")
 
 set(REQUIRED_QT_VERSION "5.7.1")
 set(REQUIRED_GLIB_VERSION "2.50.0")
@@ -57,7 +57,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 write_basic_package_version_file(
     "${CMAKE_BINARY_DIR}/${LIBFM_QT_LIBRARY_NAME}-config-version.cmake"
-    VERSION ${LIBFM_QT_LIB_VERSION}
+    VERSION ${LIBFM_QT_API_VERSION}
     COMPATIBILITY AnyNewerVersion
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,8 +144,8 @@ target_link_libraries(${LIBFM_QT_LIBRARY_NAME}
 
 # set libtool soname
 set_target_properties(${LIBFM_QT_LIBRARY_NAME} PROPERTIES
-    VERSION ${LIBFM_QT_LIB_VERSION}
-    SOVERSION ${LIBFM_QT_LIB_SOVERSION}
+    VERSION ${LIBFM_QT_ABI_VERSION}
+    SOVERSION ${LIBFM_QT_SOVERSION}
 )
 
 target_include_directories(${LIBFM_QT_LIBRARY_NAME}

--- a/src/libfm-qt.pc.in
+++ b/src/libfm-qt.pc.in
@@ -7,6 +7,6 @@ Name: libfm-qt
 Description: A Qt/glib/gio-based lib used to develop file managers providing some file management utilities.
 URL: https://github.com/lxqt/libfm-qt
 Requires: @REQUIRED_QT@
-Version: @LIBFM_QT_VERSION@
+Version: @LIBFM_QT_API_VERSION@
 Libs: -L${libdir} -l@LIBFM_QT_LIBRARY_NAME@
 Cflags: -I${includedir}


### PR DESCRIPTION
Bump API version to 0.14.0.
Bump ABI version (so name) to 6.0.0.

I noted that previously the ABI version (so version) "5.0.0" is mistakenly written into the cmake config version module while API version "0.13.1" should be used.
So I fix this, but this caused the version number returned by the find libfm-qt cmake module decreased from 5.0.0 to 0.14.0.
Not sure if this will cause side effects.