### PR TITLE
Optionally, shadow hidden icons

### DIFF
--- a/src/folderitemdelegate.h
+++ b/src/folderitemdelegate.h
@@ -89,6 +89,10 @@ public:
         return hasEditor_;
     }
 
+    void setShadowHidden(bool value) {
+        shadowHidden_ = value;
+    }
+
     virtual QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const;
 
     virtual void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const;
@@ -116,6 +120,7 @@ private:
     int iconInfoRole_;
     QColor shadowColor_;
     QSize margins_;
+    bool shadowHidden_;
     mutable bool hasEditor_;
 };
 

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -479,6 +479,7 @@ FolderView::FolderView(FolderView::ViewMode _mode, QWidget *parent):
     autoSelectionTimer_(nullptr),
     selChangedTimer_(nullptr),
     itemDelegateMargins_(QSize(3, 3)),
+    shadowHidden_(false),
     smoothScrollTimer_(nullptr),
     wheelEvent_(nullptr) {
 
@@ -609,6 +610,7 @@ void FolderView::setViewMode(ViewMode _mode) {
 
         // set our own custom delegate
         delegate = new FolderItemDelegate(treeView);
+        delegate->setShadowHidden(shadowHidden_);
         treeView->setItemDelegateForColumn(FolderModel::ColumnFileName, delegate);
     }
     else {
@@ -625,6 +627,7 @@ void FolderView::setViewMode(ViewMode _mode) {
 
         // set our own custom delegate
         delegate = new FolderItemDelegate(listView);
+        delegate->setShadowHidden(shadowHidden_);
         listView->setItemDelegateForColumn(FolderModel::ColumnFileName, delegate);
         // FIXME: should we expose the delegate?
         listView->setMovement(QListView::Static);
@@ -760,6 +763,24 @@ void FolderView::setMargins(QSize size) {
     if(itemDelegateMargins_ != size.expandedTo(QSize(0, 0))) {
         itemDelegateMargins_ = size.expandedTo(QSize(0, 0));
         updateGridSize();
+    }
+}
+
+void FolderView::setShadowHidden(bool shadowHidden) {
+    if(view && shadowHidden != shadowHidden_) {
+        shadowHidden_ = shadowHidden;
+        FolderItemDelegate* delegate = nullptr;
+        if(mode == DetailedListMode) {
+            FolderViewTreeView* treeView = static_cast<FolderViewTreeView*>(view);
+            delegate = static_cast<FolderItemDelegate*>(treeView->itemDelegateForColumn(FolderModel::ColumnFileName));
+        }
+        else {
+            FolderViewListView* listView = static_cast<FolderViewListView*>(view);
+            delegate = static_cast<FolderItemDelegate*>(listView->itemDelegateForColumn(FolderModel::ColumnFileName));
+        }
+        if(delegate) {
+            delegate->setShadowHidden(shadowHidden);
+        }
     }
 }
 

--- a/src/folderview.h
+++ b/src/folderview.h
@@ -120,6 +120,8 @@ public:
 
     void setAutoSelectionDelay(int delay);
 
+    void setShadowHidden(bool shadowHidden);
+
 protected:
     virtual bool event(QEvent* event);
     virtual void contextMenuEvent(QContextMenuEvent* event);
@@ -181,6 +183,7 @@ private:
     QTimer* selChangedTimer_;
     // the cell margins in the icon and thumbnail modes
     QSize itemDelegateMargins_;
+    bool shadowHidden_;
     // smooth scrolling:
     struct scollData {
         int delta;


### PR DESCRIPTION
Instead of a trasnlucent painter, the disabled pixmap is used for shadowing because the former is used for cut files. The text is left enabled for hidden items not to look totally disabled.

This will be followed and used by a pcmanfm-qt patch.