### PR TITLE
Fix a FTBFS due to libfm header inclusion

### DIFF
--- a/src/fileoperationdialog.cpp
+++ b/src/fileoperationdialog.cpp
@@ -23,7 +23,6 @@
 #include "renamedialog.h"
 #include <QLabel>
 #include <QMessageBox>
-#include <libfm/fm-config.h>
 #include "utilities.h"
 #include "ui_file-operation-dialog.h"
 


### PR DESCRIPTION
libfm-qt doesn't depend on libfm anymore.