### PR TITLE
Fix failure to open smb:// caused by incorrect file info handling.

### DIFF
--- a/src/core/basicfilelauncher.cpp
+++ b/src/core/basicfilelauncher.cpp
@@ -30,11 +30,10 @@ bool BasicFileLauncher::launchFiles(const FileInfoList& fileInfos, GAppLaunchCon
     // classify files according to different mimetypes
     for(auto& fileInfo : fileInfos) {
         /*
-        qDebug("path: %s, type: %s, target: %s, isDir: %i, isDesktopEntry: %i",
+        qDebug("path: %s, type: %s, target: %s, isDir: %i, isShortcut: %i, isMountable: %i, isDesktopEntry: %i",
                fileInfo->path().toString().get(), fileInfo->mimeType()->name(), fileInfo->target().c_str(),
-               fileInfo->isDir(), fileInfo->isDesktopEntry());
+               fileInfo->isDir(), fileInfo->isShortcut(), fileInfo->isMountable(), fileInfo->isDesktopEntry());
         */
-
         if(fileInfo->isMountable()) {
             if(fileInfo->target().empty()) {
                 // the mountable is not yet mounted so we have no target URI.
@@ -269,6 +268,7 @@ FilePath BasicFileLauncher::handleShortcut(const FileInfoPtr& fileInfo, GAppLaun
     // if we know the target is a dir, we are not going to open it using other apps
     // for example: `network:///smb-root' is a shortcut targeting `smb:///' and it's also a dir
     if(fileInfo->isDir()) {
+        qDebug("shortcut is dir: %s", target.c_str());
         return FilePath::fromPathStr(target.c_str());
     }
 

--- a/src/core/basicfilelauncher.h
+++ b/src/core/basicfilelauncher.h
@@ -53,7 +53,7 @@ protected:
 
     virtual bool openFolder(GAppLaunchContext* ctx, const FileInfoList& folderInfos, GErrorPtr& err);
 
-    virtual bool showError(GAppLaunchContext* ctx, GErrorPtr& err, const FilePath& path = FilePath{}, const FileInfoPtr& info = FileInfoPtr{});
+    virtual bool showError(GAppLaunchContext* ctx, const GErrorPtr& err, const FilePath& path = FilePath{}, const FileInfoPtr& info = FileInfoPtr{});
 
     virtual ExecAction askExecFile(const FileInfoPtr& file);
 

--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -36,10 +36,9 @@ void FileInfo::setFromGFileInfo(const GObjectPtr<GFileInfo>& inf, const FilePath
     size_ = g_file_info_get_size(inf.get());
 
     tmp = g_file_info_get_content_type(inf.get());
-    if(!tmp) {
-        tmp = "application/octet-stream";
+    if(tmp) {
+        mimeType_ = MimeType::fromName(tmp);
     }
-    mimeType_ = MimeType::fromName(tmp);
 
     mode_ = g_file_info_get_attribute_uint32(inf.get(), G_FILE_ATTRIBUTE_UNIX_MODE);
 
@@ -194,6 +193,10 @@ _file_is_symlink:
                 mimeType_ = MimeType::guessFromFileName(name_.c_str());
             }
         }
+    }
+
+    if(!mimeType_) {
+        mimeType_ = MimeType::fromName("application/octet-stream");
     }
 
     /* if there is a custom folder icon, use it */

--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -118,7 +118,8 @@ void FileInfo::setFromGFileInfo(const GObjectPtr<GFileInfo>& inf, const FilePath
         isDeletable_ = true;
     }
 
-    isShortcut_ = false;
+    isShortcut_ = (type == G_FILE_TYPE_SHORTCUT);
+    isMountable_ = (type == G_FILE_TYPE_MOUNTABLE);
 
     /* special handling for symlinks */
     if(g_file_info_get_is_symlink(inf.get())) {
@@ -129,7 +130,6 @@ void FileInfo::setFromGFileInfo(const GObjectPtr<GFileInfo>& inf, const FilePath
 
     switch(type) {
     case G_FILE_TYPE_SHORTCUT:
-        isShortcut_ = true;
     /* Falls through. */
     case G_FILE_TYPE_MOUNTABLE:
         uri = g_file_info_get_attribute_string(inf.get(), G_FILE_ATTRIBUTE_STANDARD_TARGET_URI);

--- a/src/core/fileinfo.h
+++ b/src/core/fileinfo.h
@@ -150,7 +150,7 @@ public:
     }
 
     bool isMountable() const {
-        return mimeType_->isMountable();
+        return isMountable_;
     }
 
     bool isShortcut() const {
@@ -238,6 +238,7 @@ private:
     std::string target_; /* target of shortcut or mountable. */
 
     bool isShortcut_ : 1; /* TRUE if file is shortcut type */
+    bool isMountable_ : 1; /* TRUE if file is mountable type */
     bool isAccessible_ : 1; /* TRUE if can be read by user */
     bool isWritable_ : 1; /* TRUE if can be written to by user */
     bool isDeletable_ : 1; /* TRUE if can be deleted by user */

--- a/src/core/fileinfojob.cpp
+++ b/src/core/fileinfojob.cpp
@@ -13,31 +13,41 @@ FileInfoJob::FileInfoJob(FilePathList paths, FilePathList deletionPaths, FilePat
 
 void FileInfoJob::exec() {
     for(const auto& path: paths_) {
-        if(!isCancelled()) {
+        if(isCancelled()) {
+            break;
+        }
+        currentPath_ = path;
+
+        bool retry;
+        do {
+            retry = false;
             GErrorPtr err;
             GFileInfoPtr inf{
                 g_file_query_info(path.gfile().get(), defaultGFileInfoQueryAttribs,
                                   G_FILE_QUERY_INFO_NONE, cancellable().get(), &err),
                 false
             };
-            if(!inf) {
-                continue;
+            if(inf) {
+                // Reuse the same dirPath object when the path remains the same (optimize for files in the same dir)
+                auto dirPath = commonDirPath_.isValid() ? commonDirPath_ : path.parent();
+                auto fileInfoPtr = std::make_shared<FileInfo>(inf, dirPath);
+
+                // FIXME: this is not elegant
+                if(cutFilesHashSet_
+                        && cutFilesHashSet_->count(path.hash())) {
+                    fileInfoPtr->bindCutFiles(cutFilesHashSet_);
+                }
+
+                results_.push_back(fileInfoPtr);
+                Q_EMIT gotInfo(path, results_.back());
             }
-
-            // Reuse the same dirPath object when the path remains the same (optimize for files in the same dir)
-            auto dirPath = commonDirPath_.isValid() ? commonDirPath_ : path.parent();
-            FileInfo fileInfo(inf, dirPath);
-
-            if(cutFilesHashSet_
-                    && cutFilesHashSet_->count(fileInfo.path().hash())) {
-                fileInfo.bindCutFiles(cutFilesHashSet_);
+            else {
+                auto act = emitError(err);
+                if(act == Job::ErrorAction::RETRY) {
+                    retry = true;
+                }
             }
-
-            auto fileInfoPtr = std::make_shared<const FileInfo>(fileInfo);
-
-            results_.push_back(fileInfoPtr);
-            Q_EMIT gotInfo(path, fileInfoPtr);
-        }
+        } while(retry && !isCancelled());
     }
 }
 

--- a/src/core/fileinfojob.h
+++ b/src/core/fileinfojob.h
@@ -27,6 +27,10 @@ public:
         return results_;
     }
 
+    const FilePath& currentPath() const {
+        return currentPath_;
+    }
+
 Q_SIGNALS:
     void gotInfo(const FilePath& path, std::shared_ptr<const FileInfo>& info);
 
@@ -39,6 +43,7 @@ private:
     FileInfoList results_;
     FilePath commonDirPath_;
     const std::shared_ptr<const HashSet> cutFilesHashSet_;
+    FilePath currentPath_;
 };
 
 } // namespace Fm

--- a/src/core/gioptrs.h
+++ b/src/core/gioptrs.h
@@ -112,6 +112,10 @@ public:
         return err_;
     }
 
+    const GError* operator->() const {
+        return err_;
+    }
+
     bool operator == (const GErrorPtr& other) const {
         return err_ == other.err_;
     }

--- a/src/filelauncher.cpp
+++ b/src/filelauncher.cpp
@@ -76,7 +76,7 @@ bool FileLauncher::openFolder(GAppLaunchContext *ctx, const FileInfoList &folder
     return BasicFileLauncher::openFolder(ctx, folderInfos, err);
 }
 
-bool FileLauncher::showError(GAppLaunchContext* /*ctx*/, GErrorPtr &err, const FilePath &path, const FileInfoPtr &info) {
+bool FileLauncher::showError(GAppLaunchContext* /*ctx*/, const GErrorPtr &err, const FilePath &path, const FileInfoPtr &info) {
     /* ask for mount if trying to launch unmounted path */
     if(err->domain == G_IO_ERROR) {
         if(path && err->code == G_IO_ERROR_NOT_MOUNTED) {

--- a/src/filelauncher.h
+++ b/src/filelauncher.h
@@ -43,7 +43,7 @@ protected:
 
     bool openFolder(GAppLaunchContext* ctx, const FileInfoList& folderInfos, GErrorPtr& err) override;
 
-    bool showError(GAppLaunchContext* ctx, GErrorPtr& err, const FilePath& path = FilePath{}, const FileInfoPtr& info = FileInfoPtr{}) override;
+    bool showError(GAppLaunchContext* ctx, const GErrorPtr &err, const FilePath& path = FilePath{}, const FileInfoPtr& info = FileInfoPtr{}) override;
 
     ExecAction askExecFile(const FileInfoPtr& file) override;
 


### PR DESCRIPTION
The issue is caused by multiple problems.

1. in libfm, shortcuts targeting smb:// is also detected as a dir but libfm-qt does not do this
2. when smb:// is first accessed, gvfs will raise the error: path is not mounted. In libfm it just treat all unmounted paths as directories, which is not correct but can workaround the smb:// case. With the hack, smb:// can be detected as dir correctly even when it's unmounted. Libfm-qt does not contain the hack.

Instead of adding the hack, I implement error handling for the "not mounted" error so smb:// can be mounted automatically upon the first access. This should IMO be the more correct behavior.
