### PR TITLE
Prevent skipping of path deletions

### DIFF
--- a/src/core/folder.h
+++ b/src/core/folder.h
@@ -164,9 +164,10 @@ private:
     /* for file monitor */
     bool has_idle_reload_handler;
     bool has_idle_update_handler;
-    std::vector<FilePath> paths_to_add;
-    std::vector<FilePath> paths_to_update;
-    std::vector<FilePath> paths_to_del;
+    FilePathList paths_to_add;
+    FilePathList paths_to_update;
+    FilePathList paths_to_del;
+    FilePathList paths_to_del_later;
     // GSList* pending_jobs;
     bool pending_change_notify;
     bool filesystem_info_pending;


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/508

Previously, deletions might be skipped because, although update signals are emitted in the proper order (deletion after creation, for example), info jobs are run asynchronously and a simple job of passing deleted paths is faster than that of adding file infos. For example, when a temporary file is added and deleted quickly, the deletion job might finish before the addition job and so, be skipped. Here, skipped deletions are remembered and completed after next info jobs.