### PR TITLE
Cancel previous list job on reloading folder

### DIFF
--- a/src/core/folder.cpp
+++ b/src/core/folder.cpp
@@ -492,8 +492,8 @@ void Folder::onDirListFinished() {
     if(job->isCancelled()) { // this is a cancelled job, ignore!
         if(job == dirlist_job) {
             dirlist_job = nullptr;
+            Q_EMIT finishLoading(); // this was the last job until now
         }
-        Q_EMIT finishLoading();
         return;
     }
     dirInfo_ = job->dirInfo();
@@ -634,6 +634,9 @@ void free_dirlist_job(FmFolder* folder) {
 
 void Folder::reload() {
     // cancel in-progress jobs if there are any
+    if(dirlist_job) {
+        dirlist_job->cancel();
+    }
     GError* err = nullptr;
     // cancel directory monitoring
     if(dirMonitor_) {


### PR DESCRIPTION
Because the second list job may be started before the first one is finished (I've seen such cases and there's no guarantee they don't happen), making `finishLoading()` be emitted twice after `startLoading()`, which can have side effects. Moreover, redundant computations are prevented.