### PR TITLE
Removes local compile definition

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,7 +164,6 @@ target_include_directories(${LIBFM_QT_LIBRARY_NAME}
 
 target_compile_definitions(${LIBFM_QT_LIBRARY_NAME}
     PRIVATE "LIBFM_QT_DATA_DIR=\"${LIBFM_QT_DATA_DIR}\""
-            "QT_NO_FOREACH"
             "GETTEXT_PACKAGE=\"\""
     PUBLIC "QT_NO_KEYWORDS"
 )


### PR DESCRIPTION
QT_NO_FOREACH is already part of LXQtCompilerSettings CMake module.