### PR TITLE
Fullscreen shortcut for file dialog

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -91,9 +91,15 @@ FileDialog::FileDialog(QWidget* parent, FilePath path) :
     ui->fileTypeCombo->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     ui->fileTypeCombo->setCurrentIndex(0);
 
+    // shortcut for showing/hiding hidden files
     QShortcut* shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_H), this);
     connect(shortcut, &QShortcut::activated, [this]() {
         proxyModel_->setShowHidden(!proxyModel_->showHidden());
+    });
+    // fullscreen shortcut
+    shortcut = new QShortcut(QKeySequence(Qt::Key_F11), this);
+    connect (shortcut, &QShortcut::activated, [this]() {
+        setWindowState(windowState() ^ Qt::WindowFullScreen);
     });
 
     // setup toolbar buttons


### PR DESCRIPTION
Fixes https://github.com/lxqt/libfm-qt/issues/244

NOTE: saveGeometry/restoreGeometry isn't added to the code because we don't want to restore the position and, especially, we don't want the dialog to be opened on another screen. So, as before, only the size is saved but `F11` is added as the fullscreen shortcut.