### PR TITLE
Emit `FolderModel::filesAdded` only after loading is finished

### DIFF
--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -36,7 +36,8 @@ namespace Fm {
 
 FolderModel::FolderModel():
     hasPendingThumbnailHandler_{false},
-    showFullNames_{false} {
+    showFullNames_{false},
+    isLoaded_{false} {
 }
 
 FolderModel::~FolderModel() {
@@ -59,17 +60,20 @@ void FolderModel::setFolder(const std::shared_ptr<Fm::Folder>& new_folder) {
         connect(folder_.get(), &Fm::Folder::filesRemoved, this, &FolderModel::onFilesRemoved);
         // handle the case if the folder is already loaded
         if(folder_->isLoaded()) {
+            isLoaded_ = true;
             insertFiles(0, folder_->files());
         }
     }
 }
 
 void FolderModel::onStartLoading() {
+    isLoaded_ = false;
     // remove all items
     removeAll();
 }
 
 void FolderModel::onFinishLoading() {
+    isLoaded_ = true;
 }
 
 void FolderModel::onFilesAdded(const Fm::FileInfoList& files) {
@@ -86,7 +90,10 @@ void FolderModel::onFilesAdded(const Fm::FileInfoList& files) {
         items.append(item);
     }
     endInsertRows();
-    Q_EMIT filesAdded(files);
+
+    if(isLoaded_) {
+        Q_EMIT filesAdded(files);
+    }
 }
 
 void FolderModel::onFilesChanged(std::vector<Fm::FileInfoPair>& files) {

--- a/src/foldermodel.h
+++ b/src/foldermodel.h
@@ -145,6 +145,8 @@ private:
     std::forward_list<ThumbnailData> thumbnailData_;
 
     bool showFullNames_;
+
+    bool isLoaded_;
 };
 
 }


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/681

The signal is used to know whether files are added to a folder, so it should be emitted after the folder is completely loaded.