### PR TITLE
Added context to folder lambda connections of file dialog

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -124,7 +124,7 @@ FileDialog::FileDialog(QWidget* parent, FilePath path) :
             // reselect files on reloading
             if(!selFiles.empty()
                && selFiles.size() <= 50) { // otherwise senseless and CPU-intensive
-                lambdaConnection_ = QObject::connect(folder_.get(), &Fm::Folder::finishLoading, [this, selFiles]() {
+                lambdaConnection_ = QObject::connect(folder_.get(), &Fm::Folder::finishLoading, this, [this, selFiles]() {
                     selectFilesOnReload(selFiles);
                 });
             }
@@ -399,7 +399,7 @@ void FileDialog::setDirectoryPath(FilePath directory, FilePath selectedPath, boo
             selectFilePathWithDelay(selectedPath);
         }
         else {
-            lambdaConnection_ = QObject::connect(folder_.get(), &Fm::Folder::finishLoading, [this, selectedPath]() {
+            lambdaConnection_ = QObject::connect(folder_.get(), &Fm::Folder::finishLoading, this, [this, selectedPath]() {
                 selectFilePathWithDelay(selectedPath);
             });
         }


### PR DESCRIPTION
Fixes https://github.com/lxqt/libfm-qt/issues/251

Adding a context is always the safest way to go but, apparently, it wasn't needed here before recent changes.