### PR TITLE
Emblem for untrusted desktop files inside home

### DIFF
--- a/src/folderitemdelegate.h
+++ b/src/folderitemdelegate.h
@@ -114,6 +114,7 @@ private:
 
 private:
     QIcon symlinkIcon_;
+    QIcon untrustedIcon_;
     QSize iconSize_;
     QSize itemSize_;
     int fileInfoRole_;


### PR DESCRIPTION
Closes https://github.com/lxqt/pcmanfm-qt/issues/751

WARNING: pcmanfm-qt should be recompiled immediately after this.

For practical reasons, `emblem-important` is added to the file icon only if it is:
 * A desktop file;
 * Untrusted; and
 * Deletable (by user).

Also, an old issue is found and fixed: previously, icons of list views could have only one emblem, while 2 emblems were possible -- and now, 3 emblems are possible (symlink, untrusted and an emblem set by the user).