### PR TITLE
Selection/deselection marks on mouse-over

### DIFF
--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -40,6 +40,8 @@ FolderItemDelegate::FolderItemDelegate(QAbstractItemView* view, QObject* parent)
     QStyledItemDelegate(parent ? parent : view),
     symlinkIcon_(QIcon::fromTheme("emblem-symbolic-link")),
     untrustedIcon_(QIcon::fromTheme("emblem-important")),
+    addIcon_(QIcon::fromTheme("list-add")),
+    removeIcon_(QIcon::fromTheme("list-remove")),
     fileInfoRole_(Fm::FolderModel::FileInfoRole),
     iconInfoRole_(-1),
     margins_(QSize(3, 3)),
@@ -170,6 +172,36 @@ void FolderItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& op
             QPoint emblemPos(opt.rect.x() + opt.rect.width() / 2, opt.rect.y() + option.decorationSize.height() / 2);
             QIcon emblem = emblems.front()->qicon();
             painter->drawPixmap(emblemPos, emblem.pixmap(option.decorationSize / 2, iconMode));
+        }
+
+        // Draw select/deselect icons outside the main icon but near its top left corner,
+        // with its 1/3 size and only if the icon size isn't smaller than 48 px
+        // (otherwise, the user could not click on them easily).
+        if(option.decorationSize.width() >= 48 && opt.state & QStyle::State_MouseOver) {
+            int s = option.decorationSize.width() / 3;
+            bool cursorOnSelectionCorner = false;
+            iconPos = QPoint(qMax(opt.rect.x(), iconPos.x() - s),
+                             qMax(opt.rect.y(), iconPos.y() - s));
+            if(const QAbstractItemView* iv = qobject_cast<const QAbstractItemView*>(opt.widget)) {
+                QPoint curPos = iv->viewport()->mapFromGlobal(QCursor::pos());
+                if(curPos.x() >= iconPos.x() && curPos.x() <= iconPos.x() + s
+                   && curPos.y() >= iconPos.y() && curPos.y() <= iconPos.y() + s) {
+                    cursorOnSelectionCorner = true;
+                }
+            }
+            if(!cursorOnSelectionCorner) { // make it translucent when not under the cursor
+                painter->save();
+                painter->setOpacity(0.6);
+            }
+            if(opt.state & QStyle::State_Selected) {
+                painter->drawPixmap(iconPos, removeIcon_.pixmap(QSize(s, s), QIcon::Normal));
+            }
+            else {
+                painter->drawPixmap(iconPos, addIcon_.pixmap(QSize(s, s), QIcon::Normal));
+            }
+            if(!cursorOnSelectionCorner) {
+                painter->restore();
+            }
         }
 
         // draw the text

--- a/src/folderitemdelegate.h
+++ b/src/folderitemdelegate.h
@@ -115,6 +115,8 @@ private:
 private:
     QIcon symlinkIcon_;
     QIcon untrustedIcon_;
+    QIcon addIcon_;
+    QIcon removeIcon_;
     QSize iconSize_;
     QSize itemSize_;
     int fileInfoRole_;

--- a/src/folderview_p.h
+++ b/src/folderview_p.h
@@ -61,6 +61,10 @@ public:
     return viewOptions();
   }
 
+  inline bool cursorOnSelectionCorner() const {
+      return cursorOnSelectionCorner_;
+  }
+
 Q_SIGNALS:
   void activatedFiltered(const QModelIndex &index);
 
@@ -72,6 +76,7 @@ private Q_SLOTS:
 
 private:
   bool activationAllowed_;
+  mutable bool cursorOnSelectionCorner_;
 };
 
 class FolderViewTreeView : public QTreeView {


### PR DESCRIPTION
Closes https://github.com/lxqt/pcmanfm-qt/issues/132

Selection(/deselection) marks are drawn on mouse-over, near top left corners of icons. Their size is 1/3 of the icon size. They are only for icon views and icon sizes >= 48 px (because otherwise, the user couldn't click on them easily).

Each selection mark has its own mouse-over state, being semi-transparent when the cursor is located inside the icon but not over the mark, and becoming opaque when under the cursor.

For now, they are icons (`list-add` and `list-remove`) but it might be possible to draw them as texts with (semi-transparent) backgrounds.