### PR TITLE
Ensure visibility of toggled path button on resizing

### DIFF
--- a/src/pathbar.h
+++ b/src/pathbar.h
@@ -82,6 +82,7 @@ private:
     PathEdit* tempPathEdit_;
 
     Fm::FilePath currentPath_;   // currently active path
+    PathButton* toggledBtn_;
 };
 
 } // namespace Fm


### PR DESCRIPTION
Fixes https://github.com/lxqt/libfm-qt/issues/260

The reason is that the toggled path button shows the current path to the user.

The code keeps track of the toggled button to find it quickly when needed.

NOTE: Recompile pcmanfm-qt after this!