### PR TITLE
Fixed file info job with parentless paths

### DIFF
--- a/src/core/fileinfojob.cpp
+++ b/src/core/fileinfojob.cpp
@@ -29,7 +29,9 @@ void FileInfoJob::exec() {
             };
             if(inf) {
                 // Reuse the same dirPath object when the path remains the same (optimize for files in the same dir)
-                auto dirPath = commonDirPath_.isValid() ? commonDirPath_ : path.parent();
+                auto dirPath = commonDirPath_.isValid() ? commonDirPath_
+                                                        : path.hasParent() ? path.parent()
+                                                                           : path; // e.g., trash:///
                 auto fileInfoPtr = std::make_shared<FileInfo>(inf, dirPath);
 
                 // FIXME: this is not elegant


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/768

A path may not have a parent, like `trash:///`. Such cases are now covered in file info jobs.