### PR TITLE
Revert the fix for parentless paths

### DIFF
--- a/src/core/fileinfojob.cpp
+++ b/src/core/fileinfojob.cpp
@@ -29,11 +29,7 @@ void FileInfoJob::exec() {
             };
             if(inf) {
                 // Reuse the same dirPath object when the path remains the same (optimize for files in the same dir)
-                auto dirPath = commonDirPath_.isValid() ? commonDirPath_
-                                                        : path.hasParent() ? path.parent()
-                                                            // search:/// does not behave normally
-                                                            : path.hasUriScheme("search") ? FilePath()
-                                                                : path; // e.g., trash:///
+                auto dirPath = commonDirPath_.isValid() ? commonDirPath_ : path.parent();
                 auto fileInfoPtr = std::make_shared<FileInfo>(inf, dirPath);
 
                 // FIXME: this is not elegant


### PR DESCRIPTION
Reverts https://github.com/lxqt/libfm-qt/commit/b11935e510804e68b393ad7bc4eb5ca12297ccf6 and https://github.com/lxqt/libfm-qt/commit/26094801dad1aedcb95a90d2b1f77c39d563adb4

That method wasn't a good idea and had side effects. A real solution should be found.