### PR TITLE
Return the correct path in `FileInfo::path()`

### DIFF
--- a/src/core/dirlistjob.cpp
+++ b/src/core/dirlistjob.cpp
@@ -50,7 +50,7 @@ _retry:
     }
     else {
         std::lock_guard<std::mutex> lock{mutex_};
-        dir_fi = std::make_shared<FileInfo>(dir_inf, dir_path.parent());
+        dir_fi = std::make_shared<FileInfo>(dir_inf, dir_path);
     }
 
     FileInfoList foundFiles;
@@ -99,7 +99,7 @@ _retry:
                 }
                 fi = fm_file_info_new_from_g_file_data(child, inf, sub);
 #endif
-                auto fileInfo = std::make_shared<FileInfo>(inf, realParentPath);
+                auto fileInfo = std::make_shared<FileInfo>(inf, FilePath(), realParentPath);
                 if(emit_files_found) {
                     // Q_EMIT filesFound();
                 }

--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -16,16 +16,22 @@ FileInfo::FileInfo() {
     // FIXME: initialize numeric data members
 }
 
-FileInfo::FileInfo(const GFileInfoPtr& inf, const FilePath& parentDirPath) {
-    setFromGFileInfo(inf, parentDirPath);
+FileInfo::FileInfo(const GFileInfoPtr& inf, const FilePath& filePath, const FilePath& parentDirPath) {
+    setFromGFileInfo(inf, filePath, parentDirPath);
 }
 
 FileInfo::~FileInfo() {
 }
 
-void FileInfo::setFromGFileInfo(const GObjectPtr<GFileInfo>& inf, const FilePath& parentDirPath) {
+void FileInfo::setFromGFileInfo(const GObjectPtr<GFileInfo>& inf, const FilePath& filePath, const FilePath& parentDirPath) {
     inf_ = inf;
-    dirPath_ = parentDirPath;
+    filePath_ = filePath;
+    if (filePath_ && filePath_.hasParent()) {
+        dirPath_ = filePath_.parent();
+    }
+    else {
+        dirPath_ = parentDirPath;
+    }
     const char* tmp, *uri;
     GIcon* gicon;
     GFileType type;

--- a/src/core/fileinfo.h
+++ b/src/core/fileinfo.h
@@ -51,7 +51,7 @@ public:
 
     explicit FileInfo();
 
-    explicit FileInfo(const GFileInfoPtr& inf, const FilePath& parentDirPath);
+    explicit FileInfo(const GFileInfoPtr& inf, const FilePath& filePath, const FilePath& parentDirPath = FilePath());
 
     virtual ~FileInfo();
 
@@ -198,14 +198,14 @@ public:
     }
 
     FilePath path() const {
-        return dirPath_ ? dirPath_.child(name_.c_str()) : FilePath::fromPathStr(name_.c_str());
+        return filePath_ ? filePath_ : dirPath_ ? dirPath_.child(name_.c_str()) : FilePath::fromPathStr(name_.c_str());
     }
 
     const FilePath& dirPath() const {
         return dirPath_;
     }
 
-    void setFromGFileInfo(const GFileInfoPtr& inf, const FilePath& parentDirPath);
+    void setFromGFileInfo(const GFileInfoPtr& inf, const FilePath& filePath, const FilePath& parentDirPath);
 
     void bindCutFiles(const std::shared_ptr<const HashSet>& cutFilesHashSet);
 
@@ -222,6 +222,7 @@ private:
     std::string name_;
     QString dispName_;
 
+    FilePath filePath_;
     FilePath dirPath_;
 
     mode_t mode_;

--- a/src/core/fileinfojob.cpp
+++ b/src/core/fileinfojob.cpp
@@ -3,11 +3,10 @@
 
 namespace Fm {
 
-FileInfoJob::FileInfoJob(FilePathList paths, FilePathList deletionPaths, FilePath commonDirPath, const std::shared_ptr<const HashSet>& cutFilesHashSet):
+FileInfoJob::FileInfoJob(FilePathList paths, FilePathList deletionPaths, const std::shared_ptr<const HashSet>& cutFilesHashSet):
     Job(),
     paths_{std::move(paths)},
     deletionPaths_{std::move(deletionPaths)},
-    commonDirPath_{std::move(commonDirPath)},
     cutFilesHashSet_{cutFilesHashSet} {
 }
 
@@ -28,9 +27,7 @@ void FileInfoJob::exec() {
                 false
             };
             if(inf) {
-                // Reuse the same dirPath object when the path remains the same (optimize for files in the same dir)
-                auto dirPath = commonDirPath_.isValid() ? commonDirPath_ : path.parent();
-                auto fileInfoPtr = std::make_shared<FileInfo>(inf, dirPath);
+                auto fileInfoPtr = std::make_shared<FileInfo>(inf, path);
 
                 // FIXME: this is not elegant
                 if(cutFilesHashSet_

--- a/src/core/fileinfojob.h
+++ b/src/core/fileinfojob.h
@@ -13,7 +13,7 @@ class LIBFM_QT_API FileInfoJob : public Job {
     Q_OBJECT
 public:
 
-    explicit FileInfoJob(FilePathList paths, FilePathList deletionPaths = FilePathList(), FilePath commonDirPath = FilePath(), const std::shared_ptr<const HashSet>& cutFilesHashSet = nullptr);
+    explicit FileInfoJob(FilePathList paths, FilePathList deletionPaths = FilePathList(), const std::shared_ptr<const HashSet>& cutFilesHashSet = nullptr);
 
     const FilePathList& paths() const {
         return paths_;
@@ -41,7 +41,6 @@ private:
     FilePathList paths_;
     FilePathList deletionPaths_;
     FileInfoList results_;
-    FilePath commonDirPath_;
     const std::shared_ptr<const HashSet> cutFilesHashSet_;
     FilePath currentPath_;
 };

--- a/src/core/filetransferjob.cpp
+++ b/src/core/filetransferjob.cpp
@@ -238,7 +238,7 @@ bool FileTransferJob::makeDir(const FilePath& srcPath, GFileInfoPtr srcInfo, Fil
                 }
 
                 FilePath newDestPath;
-                FileExistsAction opt = askRename(FileInfo{srcInfo, srcPath.parent()}, FileInfo{destInfo, destPath.parent()}, newDestPath);
+                FileExistsAction opt = askRename(FileInfo{srcInfo, srcPath}, FileInfo{destInfo, destPath}, newDestPath);
                 switch(opt) {
                 case FileOperationJob::RENAME:
                     destPath = std::move(newDestPath);
@@ -311,8 +311,8 @@ bool FileTransferJob::handleError(GErrorPtr &err, const FilePath &srcPath, const
         // ask the user to rename or overwrite the existing file
         if(!isCancelled() && destInfo) {
             FilePath newDestPath;
-            FileExistsAction opt = askRename(FileInfo{srcInfo, srcPath.parent()},
-                                             FileInfo{destInfo, destPath.parent()},
+            FileExistsAction opt = askRename(FileInfo{srcInfo, srcPath},
+                                             FileInfo{destInfo, destPath},
                                              newDestPath);
             switch(opt) {
             case FileOperationJob::RENAME:

--- a/src/core/folder.cpp
+++ b/src/core/folder.cpp
@@ -223,14 +223,14 @@ void Folder::onFileInfoFinished() {
         // add/update the file only if it isn't going to be deleted
         else if(std::find(deletionPaths.cbegin(), deletionPaths.cend(), path) == deletionPaths.cend()
                 && std::find(paths_to_del_later.cbegin(), paths_to_del_later.cend(), path) == paths_to_del_later.cend()) {
-            auto it = files_.find(info->name());
+            auto it = files_.find(info->path().baseName().get());
             if(it != files_.end()) { // the file already exists, update
                 files_to_update.push_back(std::make_pair(it->second, info));
             }
             else { // newly added
                 files_to_add.push_back(info);
             }
-            files_[info->name()] = info;
+            files_[info->path().baseName().get()] = info;
         }
     }
     if(!files_to_add.empty()) {
@@ -286,8 +286,7 @@ void Folder::processPendingChanges() {
         paths.insert(paths.end(), paths_to_add.cbegin(), paths_to_add.cend());
         paths.insert(paths.end(), paths_to_update.cbegin(), paths_to_update.cend());
         deletionPaths.insert(deletionPaths.end(), paths_to_del.cbegin(), paths_to_del.cend());
-        info_job = new FileInfoJob{paths, deletionPaths, dirPath_,
-                                   hasCutFiles() ? cutFilesHashSet_ : nullptr};
+        info_job = new FileInfoJob{paths, deletionPaths, hasCutFiles() ? cutFilesHashSet_ : nullptr};
         paths_to_update.clear();
         paths_to_add.clear();
         paths_to_del.clear();
@@ -522,21 +521,21 @@ void Folder::onDirListFinished() {
     if(strcmp(dirPath_.uriScheme().get(), "search") == 0) {
         files_to_add = infos;
         for(auto& file: files_to_add) {
-            files_[file->name()] = file;
+            files_[file->path().baseName().get()] = file;
         }
     }
     else {
         auto info_it = infos.cbegin();
         for(; info_it != infos.cend(); ++info_it) {
             const auto& info = *info_it;
-            auto it = files_.find(info->name());
+            auto it = files_.find(info->path().baseName().get());
             if(it != files_.end()) {
                 files_to_update.push_back(std::make_pair(it->second, info));
             }
             else {
                 files_to_add.push_back(info);
             }
-            files_[info->name()] = info;
+            files_[info->path().baseName().get()] = info;
         }
     }
 

--- a/src/core/folder.h
+++ b/src/core/folder.h
@@ -175,6 +175,8 @@ private:
     bool wants_incremental;
     bool stop_emission; /* don't set it 1 bit to not lock other bits */
 
+    // NOTE: Here, FileInfo::path().baseName().get() should be used as the key value, not FileInfo::name(),
+    // because the latter is not always the same as the former and the former will be used for comparison.
     std::unordered_map<const std::string, std::shared_ptr<const FileInfo>, std::hash<std::string>> files_;
 
     /* filesystem info - set in query thread, read in main */


### PR DESCRIPTION
This closes https://github.com/lxqt/pcmanfm-qt/issues/768, closes https://github.com/lxqt/pcmanfm-qt/issues/769, closes https://github.com/lxqt/pcmanfm-qt/issues/770, and closes https://github.com/lxqt/pcmanfm-qt/issues/646

Explanation:

Feeding the parent directory path into the ctor of `FileInfo` doesn't always guarantee a correct return value for `FileInfo::path()` beause (1) the parent directory may not exist, in which case, `/` will be returned for all paths like `X:///` (see https://github.com/lxqt/pcmanfm-qt/issues/768), and (2) even if the parent directory exists, `FileInfo::path()` might result in an incorrect path (see https://github.com/lxqt/pcmanfm-qt/issues/769 and https://github.com/lxqt/pcmanfm-qt/issues/770).

This patch fixes the issue by giving the path itself to the ctor of `FileInfo` wherever possible. (The parent directory is only used in the case of `GFileEnumerator`, which always gives correct paths.)

pcmanfm-qt and other libfm-qt based apps should be recompiled.

NOTE 1: `commonDirPath_` is removed from `FileInfoJob` because it didn't do a real job. Moreover, the class didn't guarantee that it was the parent directory of all paths.

NOTE 2: As far as I tested, this also fixes https://github.com/lxqt/pcmanfm-qt/issues/646 -- at least, for the first time, the root pcmanfm-qt transferred 10 GiB of about 4000 files to an ext4-formatted external drive without any problem.