### PR TITLE
Added a missing `break` in TrashJob

### DIFF
--- a/src/core/trashjob.cpp
+++ b/src/core/trashjob.cpp
@@ -49,6 +49,7 @@ void TrashJob::exec() {
                 // if trashing is not supported by the file system
                 if(err.domain() == G_IO_ERROR && err.code() == G_IO_ERROR_NOT_SUPPORTED) {
                     unsupportedFiles_.push_back(path);
+                     break;
                 }
                 else {
                     ErrorAction act = emitError(err, ErrorSeverity::MODERATE);


### PR DESCRIPTION
Its lack caused an infinite loop when the file couldn't be trashed. Its presence offers the deletion option when trashing is impossible.