### PR TITLE
Device usage bar for Properties dialog

### DIFF
--- a/src/file-props.ui
+++ b/src/file-props.ui
@@ -289,6 +289,59 @@
          </property>
         </widget>
        </item>
+       <item row="11" column="0">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>5</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="12" column="0">
+        <widget class="QLabel" name="deviceLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Device Usage:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="1">
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <property name="spacing">
+          <number>5</number>
+         </property>
+         <item>
+          <widget class="QProgressBar" name="progressBar">
+           <property name="value">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="spaceLabel">
+           <property name="text">
+            <string/>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="permissionsPage">

--- a/src/filepropsdialog.cpp
+++ b/src/filepropsdialog.cpp
@@ -321,6 +321,25 @@ void FilePropsDialog::initGeneralPage() {
     connect(totalSizeJob, &Fm::TotalSizeJob::finished, this, &FilePropsDialog::onDeepCountJobFinished, Qt::BlockingQueuedConnection);
     totalSizeJob->setAutoDelete(true);
     totalSizeJob->runAsync();
+
+    // disk usage
+    auto folder = Fm::Folder::fromPath(fileInfo->dirPath());
+    if(!folder->isLoaded() && fileInfo->isDir()) { // an empty space is right clicked
+        folder = Fm::Folder::fromPath(fileInfo->path());
+    }
+    guint64 free, total;
+    if(folder->getFilesystemInfo(&total, &free)) {
+        ui->progressBar->setValue(qRound(static_cast<qreal>((total - free) * 100) / static_cast<qreal>(total)));
+        ui->progressBar->setFormat(tr("%p% used"));
+        ui->spaceLabel->setText(tr("%1 Free of %2")
+                                .arg(formatFileSize(free, false))
+                                .arg(formatFileSize(total, false)));
+    }
+    else {
+        ui->deviceLabel->setVisible(false);
+        ui->spaceLabel->setVisible(false);
+        ui->progressBar->setVisible(false);
+    }
 }
 
 void FilePropsDialog::onDeepCountJobFinished() {


### PR DESCRIPTION
Closes https://github.com/lxqt/pcmanfm-qt/issues/650

Let's show the device usage by a bar because the device is a property of a file that resides on it.