### PR TITLE
Set dir list job cancellation error to mild

### DIFF
--- a/src/core/dirlistjob.cpp
+++ b/src/core/dirlistjob.cpp
@@ -127,7 +127,9 @@ _retry:
         g_file_enumerator_close(enu.get(), cancellable().get(), &err);
     }
     else {
-        emitError(err, ErrorSeverity::CRITICAL);
+        emitError(err, err.domain() == G_IO_ERROR && err.code() == G_IO_ERROR_CANCELLED
+                       ? ErrorSeverity::MILD // may happen at Folder::reload()
+                       : ErrorSeverity::CRITICAL);
     }
 
     // qDebug() << "END LISTING:" << dir_path.toString().get();


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/789

A directory list job may be legally cancelled at `Folder::reload()`, in which case, pcmanfm-qt shouldn't show an error message (pcmanfm-qt only shows errors with severities greater than `ErrorSeverity::MILD`).