### PR TITLE
replace mempcpy with basic memcpy

### DIFF
--- a/src/core/thumbnailjob.cpp
+++ b/src/core/thumbnailjob.cpp
@@ -96,7 +96,7 @@ QImage ThumbnailJob::loadForFile(const std::shared_ptr<const FileInfo> &file) {
     // calculate md5 hash for the uri of the original file
     g_checksum_update(md5Calc_, reinterpret_cast<const unsigned char*>(uri.get()), -1);
     memcpy(thumbnailName, g_checksum_get_string(md5Calc_), 32);
-    mempcpy(thumbnailName + 32, ".png", 5);
+    memcpy(thumbnailName + 32, ".png", 5);
     g_checksum_reset(md5Calc_); // reset the checksum calculator for next use
 
     QString thumbnailFilename = thumbnailDir;


### PR DESCRIPTION
in this context GNU-specific mempcpy offers no advantages over standard memcpy