### PR TITLE
Don't launch unselected current item on pressing Enter

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -538,7 +538,9 @@ FolderView::~FolderView() {
 }
 
 void FolderView::onItemActivated(QModelIndex index) {
-    if(index.isValid() && index.model()) {
+    QItemSelectionModel* selModel = selectionModel();
+    if(index.isValid() && index.model()
+       && selModel && selModel->isSelected(index)) { // do nothing when the item is not selected
         QVariant data = index.model()->data(index, FolderModel::FileInfoRole);
         auto info = data.value<std::shared_ptr<const Fm::FileInfo>>();
         if(info) {


### PR DESCRIPTION
Fixes https://github.com/lxqt/lxqt/issues/534

Qt "activates" the current item (that has focus) on pressing `Enter` even when it isn't selected. However, launching an unselected item with `Enter` is not the behavior we expect from a file manager.