### PR TITLE
Don't update trash icon too fast

### DIFF
--- a/src/placesmodel.h
+++ b/src/placesmodel.h
@@ -129,6 +129,7 @@ private:
     QStandardItem* bookmarksRoot;
     PlacesModelItem* trashItem_;
     GFileMonitor* trashMonitor_;
+    QTimer* trashUpdateTimer_;
     PlacesModelItem* desktopItem;
     PlacesModelItem* homeItem;
     PlacesModelItem* computerItem;


### PR DESCRIPTION
Instead, use a timer to limit the updates to 4 times per second at most.