### PR TITLE
Fixes for template actions

### DIFF
--- a/src/core/templates.cpp
+++ b/src/core/templates.cpp
@@ -58,6 +58,12 @@ void Templates::addTemplateDir(const char* dirPathName) {
     auto dir_path = FilePath::fromLocalPath(dirPathName);
     if(dir_path.isValid()) {
         auto folder = Folder::fromPath(dir_path);
+        if(folder->isLoaded()) {
+            const auto files = folder->files();
+            for(auto& file : files) {
+                items_.emplace_back(std::make_shared<TemplateItem>(file));
+            }
+        }
         connect(folder.get(), &Folder::filesAdded, this, &Templates::onFilesAdded);
         connect(folder.get(), &Folder::filesChanged, this, &Templates::onFilesChanged);
         connect(folder.get(), &Folder::filesRemoved, this, &Templates::onFilesRemoved);


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/828 and fixes https://github.com/lxqt/pcmanfm-qt/issues/829

Previously, template actions weren't sorted alphabetically and weren't shown when the template directory was already loaded (opened in pcmanfm-qt). This patch fixes both issues.