### PR TITLE
Fix invisible view icons with HDPI scaling

### DIFF
--- a/src/core/iconinfo_p.h
+++ b/src/core/iconinfo_p.h
@@ -118,6 +118,13 @@ void IconEngine::virtual_hook(int id, void* data) {
         break;
     }
 #endif
+#if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
+    case QIconEngine::ScaledPixmapHook: {
+        auto* arg = reinterpret_cast<QIconEngine::ScaledPixmapArgument*>(data);
+        arg->pixmap = info ? info->internalQicon().pixmap(arg->size, arg->mode, arg->state) : QPixmap{};
+        break;
+    }
+#endif
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/834

To test this, stop pcmanfm-qt and run it with `QT_SCALE_FACTOR=2 pcmanfm-qt`: previously, the view icons were invisible.

Blurry side-pane icons with PNG icon sets and HDPI scaling are not specific to pcmanfm-qt/libfm-qt but are caused by an issue in libqtxdg, which will be fixed later.