### PR TITLE
Fixed the problem with deletion queues

### DIFF
--- a/src/core/fileinfojob.cpp
+++ b/src/core/fileinfojob.cpp
@@ -3,10 +3,9 @@
 
 namespace Fm {
 
-FileInfoJob::FileInfoJob(FilePathList paths, FilePathList deletionPaths, const std::shared_ptr<const HashSet>& cutFilesHashSet):
+FileInfoJob::FileInfoJob(FilePathList paths, const std::shared_ptr<const HashSet>& cutFilesHashSet):
     Job(),
     paths_{std::move(paths)},
-    deletionPaths_{std::move(deletionPaths)},
     cutFilesHashSet_{cutFilesHashSet} {
 }
 

--- a/src/core/fileinfojob.h
+++ b/src/core/fileinfojob.h
@@ -13,14 +13,10 @@ class LIBFM_QT_API FileInfoJob : public Job {
     Q_OBJECT
 public:
 
-    explicit FileInfoJob(FilePathList paths, FilePathList deletionPaths = FilePathList(), const std::shared_ptr<const HashSet>& cutFilesHashSet = nullptr);
+    explicit FileInfoJob(FilePathList paths, const std::shared_ptr<const HashSet>& cutFilesHashSet = nullptr);
 
     const FilePathList& paths() const {
         return paths_;
-    }
-
-    const FilePathList& deletionPaths() const {
-        return deletionPaths_;
     }
 
     const FileInfoList& files() const {
@@ -39,7 +35,6 @@ protected:
 
 private:
     FilePathList paths_;
-    FilePathList deletionPaths_;
     FileInfoList results_;
     const std::shared_ptr<const HashSet> cutFilesHashSet_;
     FilePath currentPath_;

--- a/src/core/folder.h
+++ b/src/core/folder.h
@@ -167,7 +167,6 @@ private:
     FilePathList paths_to_add;
     FilePathList paths_to_update;
     FilePathList paths_to_del;
-    FilePathList paths_to_del_later;
     // GSList* pending_jobs;
     bool pending_change_notify;
     bool filesystem_info_pending;


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/848

The code of `folder.cpp` gets information about file changes (additions, updates and deletions) from GIO, processes that info, and then determines whether a file should be added, updated or deleted.

In the @PCMan's original code, file deletion was processed immediately, while addition and update were processed by file info jobs, which take a short time to finish. As a result, deletion might be premature. For example, if a single file was created and immediately deleted, processing its deletion before its creation would mean the deletion of a file that doesn't exist yet (doing nothing) and then creating it, which would result in showing a nonexistent file. Similar problems could happen very randomly and rarely.

Later, to fix the problem of premature deletion, I tried to include deletion in the file info job but, since file info jobs run asynchronously, deletion might still happen too soon. There was another attempt at delaying the deletion when needed but it worked only in certain scenarios.

So, in my opinion, *the only way of fixing premature deletions is preventing file info jobs from overlapping each other.*

That's what the current patch does (in addition to correcting update queues). It also simplifies the code by starting from @PCMan's original code again.

The patch is experimental. Its logic seems correct to me but, IMO, it needs @PCMan's review (he might dislike the idea of nonoverlapping file info jobs).