### PR TITLE
No copy into self

### DIFF
--- a/src/core/filepath.h
+++ b/src/core/filepath.h
@@ -83,11 +83,11 @@ public:
         return g_file_has_parent(gfile_.get(), nullptr);
     }
 
-    bool isParentOf(const FilePath& other) {
+    bool isParentOf(const FilePath& other) const {
         return g_file_has_parent(other.gfile_.get(), gfile_.get());
     }
 
-    bool isPrefixOf(const FilePath& other) {
+    bool isPrefixOf(const FilePath& other) const {
         return g_file_has_prefix(other.gfile_.get(), gfile_.get());
     }
 

--- a/src/core/filetransferjob.cpp
+++ b/src/core/filetransferjob.cpp
@@ -449,7 +449,18 @@ bool FileTransferJob::copyFile(const FilePath& srcPath, const GFileInfoPtr& srcI
     if(!skip) {
         switch(file_type) {
         case G_FILE_TYPE_DIRECTORY:
-            success = makeDir(srcPath, srcInfo, destPath);
+            // prevent a dir from being copied into itself
+            if(srcPath.isPrefixOf(destPath)) {
+                GErrorPtr err = GErrorPtr{
+                                G_IO_ERROR,
+                                G_IO_ERROR_NOT_SUPPORTED,
+                                tr("Cannot copy a directory into itself!")
+                };
+                emitError(err, ErrorSeverity::MODERATE);
+            }
+            else {
+                success = makeDir(srcPath, srcInfo, destPath);
+            }
             break;
         case G_FILE_TYPE_SPECIAL:
             success = copySpecialFile(srcPath, srcInfo, destPath);


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/858

Prevents a dir from being copied into itself (or into a subdir of itself) and shows an error message.

Also, `const` is added to two `FilePath` methods; one of them was needed here.