### PR TITLE
Fixed mimetype filters in LXQt file dialog

### DIFF
--- a/src/filedialog.h
+++ b/src/filedialog.h
@@ -5,7 +5,7 @@
 #include "core/filepath.h"
 
 #include <QFileDialog>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <vector>
 #include <memory>
 #include "folderview.h"
@@ -150,7 +150,7 @@ private:
         void update();
 
         FileDialog* dlg_;
-        std::vector<QRegExp> patterns_;
+        std::vector<QRegularExpression> patterns_;
     };
 
     bool isLabelExplicitlySet(QFileDialog::DialogLabel label) const {


### PR DESCRIPTION
Fixes https://github.com/lxqt/libfm-qt/issues/342

(1) The problem was just a typo, which is corrected.

(2) I also took the liberty of replacing `QRegExp` with `QRegularExpression` because the former is deprecated -- I know it's a bad practice to have two changes in one PR but I might never do it if not here.

NOTE: The only way of testing this is using `QFileDialog::setMimeTypeFilters()` in a code. It passed my tests though.