### PR TITLE
Added custom widths and visibility for detailed columns

### DIFF
--- a/src/folderview.h
+++ b/src/folderview.h
@@ -64,7 +64,7 @@ public:
     friend class FolderViewTreeView;
     friend class FolderViewListView;
 
-    explicit FolderView(ViewMode _mode = IconMode, QWidget* parent = 0);
+    explicit FolderView(ViewMode _mode = IconMode, QWidget* parent = nullptr);
 
     explicit FolderView(QWidget* parent): FolderView{IconMode, parent} {}
 
@@ -122,6 +122,16 @@ public:
 
     void setShadowHidden(bool shadowHidden);
 
+    QList<int> getCustomColumnWidths() const {
+        return customColumnWidths_;
+    }
+    void setCustomColumnWidths(const QList<int> &widths);
+
+    QList<int> getHiddenColumns() const {
+        return hiddenColumns_.toList();
+    }
+    void setHiddenColumns(const QList<int> &columns);
+
 protected:
     virtual bool event(QEvent* event);
     virtual void contextMenuEvent(QContextMenuEvent* event);
@@ -170,6 +180,9 @@ Q_SIGNALS:
     void selChanged();
     void sortChanged();
 
+    void columnResizedByUser();
+    void columnHiddenByUser();
+
 private:
 
     QAbstractItemView* view;
@@ -192,6 +205,8 @@ private:
     QTimer *smoothScrollTimer_;
     QWheelEvent *wheelEvent_;
     QList<scollData> queuedScrollSteps_;
+    QList<int> customColumnWidths_;
+    QSet<int> hiddenColumns_;
 };
 
 }

--- a/src/folderview_p.h
+++ b/src/folderview_p.h
@@ -35,7 +35,7 @@ class FolderViewListView : public QListView {
   Q_OBJECT
 public:
   friend class FolderView;
-  FolderViewListView(QWidget* parent = 0);
+  FolderViewListView(QWidget* parent = nullptr);
   virtual ~FolderViewListView();
   virtual void startDrag(Qt::DropActions supportedActions);
   virtual void mousePressEvent(QMouseEvent* event);
@@ -83,7 +83,7 @@ class FolderViewTreeView : public QTreeView {
   Q_OBJECT
 public:
   friend class FolderView;
-  FolderViewTreeView(QWidget* parent = 0);
+  FolderViewTreeView(QWidget* parent = nullptr);
   virtual ~FolderViewTreeView();
   virtual void setModel(QAbstractItemModel* model);
   virtual void mousePressEvent(QMouseEvent* event);
@@ -107,18 +107,28 @@ public:
     QAbstractItemView::keyboardSearch(search); // let items be selected by typing
   }
 
+  void setCustomColumnWidths(const QList<int> &widths);
+
+  void setHiddenColumns(const QSet<int> &columns);
+
 Q_SIGNALS:
   void activatedFiltered(const QModelIndex &index);
+  void columnResizedByUser(int visualIndex, int newWidth);
+  void autoResizeEnabled();
+  void columnHiddenByUser(int visibleIndex, bool hidden);
 
 private Q_SLOTS:
   void layoutColumns();
   void activation(const QModelIndex &index);
   void onSortFilterChanged();
+  void headerContextMenu(const QPoint &p);
 
 private:
   bool doingLayout_;
   QTimer* layoutTimer_;
   bool activationAllowed_;
+  QList<int> customColumnWidths_;
+  QSet<int> hiddenColumns_;
 };
 
 


### PR DESCRIPTION
The options are in the header right-click menu. They already work for the current view but, of course, saving/restoring should not be done by libfm-qt. Hiding the file name column is not allowed.

A small pcmanfm-qt patch will follow this one soon to save and restore custom settings. LXQt file dialog could also be easily patched later.

NOTE 1: pcmanfm-qt should be recompiled after this, preferably with the above-mentioned patch.

NOTE 2: The previous patches about fixing file group should be applied before this.