### PR TITLE
Make setting trust possible anytime

### DIFF
--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -247,7 +247,7 @@ FileMenu::~FileMenu() {
 }
 
 void FileMenu::addTrustAction() {
-    if(info_->isExecutableType() && (!fileLauncher_ || !fileLauncher_->quickExec())) {
+    if(info_->isExecutableType()) {
         QAction* trustAction = new QAction(files_.size() > 1
                                              ? tr("Trust selected executables")
                                              : tr("Trust this executable"),


### PR DESCRIPTION
If a file is executable the option should be available in the context menu.
The part
&& (!fileLauncher_ || !fileLauncher_->quickExec()) is superfluous in that case.

fixes lxqt/libfm-qt/issues/354