### PR TITLE
Add KDevelop project files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build*/
 Session.vim
 .netrwhist
 *~
+.kdev4
+*.kdev4


### PR DESCRIPTION
The project files of KDevelop are not part of the source, so ignore
them.