### PR TITLE
Give window parents to some app-modal dialogs

### DIFF
--- a/src/createnewmenu.cpp
+++ b/src/createnewmenu.cpp
@@ -81,13 +81,13 @@ CreateNewMenu::~CreateNewMenu() {
 
 void CreateNewMenu::onCreateNewFile() {
     if(dirPath_) {
-        createFileOrFolder(CreateNewTextFile, dirPath_);
+        createFileOrFolder(CreateNewTextFile, dirPath_, nullptr, dialogParent_);
     }
 }
 
 void CreateNewMenu::onCreateNewFolder() {
     if(dirPath_) {
-        createFileOrFolder(CreateNewFolder, dirPath_);
+        createFileOrFolder(CreateNewFolder, dirPath_, nullptr, dialogParent_);
     }
 }
 

--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -121,7 +121,7 @@ FileMenu::FileMenu(Fm::FileInfoList files, std::shared_ptr<const Fm::FileInfo> i
 
     createAction_ = new QAction(tr("Create &New"), this);
     Fm::FilePath dirPath = files_.size() == 1 && info_->isDir() ? path : cwd_;
-    createAction_->setMenu(new CreateNewMenu(nullptr, dirPath, this));
+    createAction_->setMenu(new CreateNewMenu(parent, dirPath, this));
     addAction(createAction_);
 
     separator2_ = addSeparator();
@@ -363,15 +363,15 @@ void FileMenu::onCutTriggered() {
 void FileMenu::onDeleteTriggered() {
     auto paths = files_.paths();
     if(useTrash_) {
-        FileOperation::trashFiles(paths, confirmTrash_);
+        FileOperation::trashFiles(paths, confirmTrash_, parentWidget());
     }
     else {
-        FileOperation::deleteFiles(paths, confirmDelete_);
+        FileOperation::deleteFiles(paths, confirmDelete_, parentWidget());
     }
 }
 
 void FileMenu::onUnTrashTriggered() {
-    FileOperation::unTrashFiles(files_.paths());
+    FileOperation::unTrashFiles(files_.paths(), parentWidget());
 }
 
 void FileMenu::onPasteTriggered() {

--- a/src/fileoperation.cpp
+++ b/src/fileoperation.cpp
@@ -304,9 +304,10 @@ void FileOperation::onJobFinish() {
         /* some files cannot be trashed because underlying filesystems don't support it. */
         auto unsupportedFiles = trashJob->unsupportedFiles();
         if(!unsupportedFiles.empty()) { /* delete them instead */
-            /* FIXME: parent window might be already destroyed! */
-            QWidget* parent = nullptr; // FIXME: currently, parent window is not set
-            if(QMessageBox::question(parent, tr("Error"),
+            /* parent object is not destroyed before this */
+            QWidget* pWidget = qobject_cast<QWidget*>(parent());
+            if(QMessageBox::question(pWidget ? pWidget->window() : nullptr,
+                                     tr("Error"),
                                      tr("Some files cannot be moved to trash can because "
                                         "the underlying file systems don't support this operation.\n"
                                         "Do you want to delete them instead?")) == QMessageBox::Yes) {
@@ -372,7 +373,8 @@ FileOperation *FileOperation::symlinkFiles(FilePathList srcFiles, FilePathList d
 //static
 FileOperation* FileOperation::deleteFiles(Fm::FilePathList srcFiles, bool prompt, QWidget* parent) {
     if(prompt) {
-        int result = QMessageBox::warning(parent, tr("Confirm"),
+        int result = QMessageBox::warning(parent ? parent->window() : nullptr,
+                                          tr("Confirm"),
                                           tr("Do you want to delete the selected files?"),
                                           QMessageBox::Yes | QMessageBox::No,
                                           QMessageBox::No);
@@ -381,7 +383,7 @@ FileOperation* FileOperation::deleteFiles(Fm::FilePathList srcFiles, bool prompt
         }
     }
 
-    FileOperation* op = new FileOperation(FileOperation::Delete, std::move(srcFiles));
+    FileOperation* op = new FileOperation(FileOperation::Delete, std::move(srcFiles), parent);
     op->run();
     return op;
 }
@@ -389,7 +391,8 @@ FileOperation* FileOperation::deleteFiles(Fm::FilePathList srcFiles, bool prompt
 //static
 FileOperation* FileOperation::trashFiles(Fm::FilePathList srcFiles, bool prompt, QWidget* parent) {
     if(prompt) {
-        int result = QMessageBox::warning(parent, tr("Confirm"),
+        int result = QMessageBox::warning(parent ? parent->window() : nullptr,
+                                          tr("Confirm"),
                                           tr("Do you want to move the selected files to trash can?"),
                                           QMessageBox::Yes | QMessageBox::No,
                                           QMessageBox::No);
@@ -398,7 +401,7 @@ FileOperation* FileOperation::trashFiles(Fm::FilePathList srcFiles, bool prompt,
         }
     }
 
-    FileOperation* op = new FileOperation(FileOperation::Trash, std::move(srcFiles));
+    FileOperation* op = new FileOperation(FileOperation::Trash, std::move(srcFiles), parent);
     op->run();
     return op;
 }

--- a/src/fileoperation.h
+++ b/src/fileoperation.h
@@ -47,7 +47,7 @@ public:
     };
 
 public:
-    explicit FileOperation(Type type, Fm::FilePathList srcFiles, QObject* parent = 0);
+    explicit FileOperation(Type type, Fm::FilePathList srcFiles, QObject* parent = nullptr);
 
     virtual ~FileOperation();
 
@@ -93,37 +93,37 @@ public:
     }
 
     // convinient static functions
-    static FileOperation* copyFiles(Fm::FilePathList srcFiles, Fm::FilePath dest, QWidget* parent = 0);
+    static FileOperation* copyFiles(Fm::FilePathList srcFiles, Fm::FilePath dest, QWidget* parent = nullptr);
 
-    static FileOperation* copyFiles(Fm::FilePathList srcFiles, Fm::FilePathList destFiles, QWidget* parent = 0);
+    static FileOperation* copyFiles(Fm::FilePathList srcFiles, Fm::FilePathList destFiles, QWidget* parent = nullptr);
 
-    static FileOperation* copyFile(Fm::FilePath srcFile, Fm::FilePath destFile, QWidget* parent = 0) {
+    static FileOperation* copyFile(Fm::FilePath srcFile, Fm::FilePath destFile, QWidget* parent = nullptr) {
         return copyFiles(FilePathList{std::move(srcFile)}, FilePathList{std::move(destFile)}, parent);
     }
 
-    static FileOperation* moveFiles(Fm::FilePathList srcFiles, Fm::FilePath dest, QWidget* parent = 0);
+    static FileOperation* moveFiles(Fm::FilePathList srcFiles, Fm::FilePath dest, QWidget* parent = nullptr);
 
-    static FileOperation* moveFiles(Fm::FilePathList srcFiles, Fm::FilePathList destFiles, QWidget* parent = 0);
+    static FileOperation* moveFiles(Fm::FilePathList srcFiles, Fm::FilePathList destFiles, QWidget* parent = nullptr);
 
-    static FileOperation* moveFile(Fm::FilePath srcFile, Fm::FilePath destFile, QWidget* parent = 0) {
+    static FileOperation* moveFile(Fm::FilePath srcFile, Fm::FilePath destFile, QWidget* parent = nullptr) {
         return moveFiles(FilePathList{std::move(srcFile)}, FilePathList{std::move(destFile)}, parent);
     }
 
-    static FileOperation* symlinkFiles(Fm::FilePathList srcFiles, Fm::FilePath dest, QWidget* parent = 0);
+    static FileOperation* symlinkFiles(Fm::FilePathList srcFiles, Fm::FilePath dest, QWidget* parent = nullptr);
 
-    static FileOperation* symlinkFiles(Fm::FilePathList srcFiles, Fm::FilePathList destFiles, QWidget* parent = 0);
+    static FileOperation* symlinkFiles(Fm::FilePathList srcFiles, Fm::FilePathList destFiles, QWidget* parent = nullptr);
 
-    static FileOperation* symlinkFile(Fm::FilePath srcFile, Fm::FilePath destFile, QWidget* parent = 0) {
+    static FileOperation* symlinkFile(Fm::FilePath srcFile, Fm::FilePath destFile, QWidget* parent = nullptr) {
         return symlinkFiles(FilePathList{std::move(srcFile)}, FilePathList{std::move(destFile)}, parent);
     }
 
-    static FileOperation* deleteFiles(Fm::FilePathList srcFiles, bool promp = true, QWidget* parent = 0);
+    static FileOperation* deleteFiles(Fm::FilePathList srcFiles, bool promp = true, QWidget* parent = nullptr);
 
-    static FileOperation* trashFiles(Fm::FilePathList srcFiles, bool promp = true, QWidget* parent = 0);
+    static FileOperation* trashFiles(Fm::FilePathList srcFiles, bool promp = true, QWidget* parent = nullptr);
 
-    static FileOperation* unTrashFiles(Fm::FilePathList srcFiles, QWidget* parent = 0);
+    static FileOperation* unTrashFiles(Fm::FilePathList srcFiles, QWidget* parent = nullptr);
 
-    static FileOperation* changeAttrFiles(Fm::FilePathList srcFiles, QWidget* parent = 0);
+    static FileOperation* changeAttrFiles(Fm::FilePathList srcFiles, QWidget* parent = nullptr);
 
 Q_SIGNALS:
     void finished();

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1388,9 +1388,7 @@ void FolderView::onFileClicked(int type, const std::shared_ptr<const Fm::FileInf
             // show context menu
             auto files = selectedFiles();
             if(!files.empty()) {
-                Fm::FileMenu* fileMenu = (view && files.size() == 1)
-                                         ? new Fm::FileMenu(files, fileInfo, folderPath, isWritableDir, QString(), view)
-                                         : new Fm::FileMenu(files, fileInfo, folderPath, isWritableDir);
+                Fm::FileMenu* fileMenu = new Fm::FileMenu(files, fileInfo, folderPath, isWritableDir, QString(), view);
                 fileMenu->setFileLauncher(fileLauncher_);
                 fileMenu->addTrustAction();
                 prepareFileMenu(fileMenu);

--- a/src/placesview.cpp
+++ b/src/placesview.cpp
@@ -336,7 +336,7 @@ void PlacesView::dropEvent(QDropEvent* event) {
 void PlacesView::onEmptyTrash() {
     Fm::FilePathList files;
     files.push_back(Fm::FilePath::fromUri("trash:///"));
-    Fm::FileOperation::deleteFiles(std::move(files));
+    Fm::FileOperation::deleteFiles(std::move(files), true, this);
 }
 
 void PlacesView::onMoveBookmarkUp() {

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -166,7 +166,7 @@ bool changeFileName(const Fm::FilePath& filePath, const QString& newName, QWidge
                     nullptr, /* make this cancellable later. */
                     nullptr, nullptr, &err)) {
         if (showMessage){
-            QMessageBox::critical(parent, QObject::tr("Error"), err.message());
+            QMessageBox::critical(parent ? parent->window() : nullptr, QObject::tr("Error"), err.message());
         }
         return false;
     }
@@ -174,7 +174,7 @@ bool changeFileName(const Fm::FilePath& filePath, const QString& newName, QWidge
 }
 
 bool renameFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent) {
-    FilenameDialog dlg(parent);
+    FilenameDialog dlg(parent ? parent->window() : nullptr);
     dlg.setWindowTitle(QObject::tr("Rename File"));
     dlg.setLabelText(QObject::tr("Please enter a new name:"));
     // FIXME: what's the best way to handle non-UTF8 filename encoding here?
@@ -226,7 +226,8 @@ void createFileOrFolder(CreateFileType type, FilePath parentDir, const TemplateI
 _retry:
     // ask the user to input a file name
     bool ok;
-    QString new_name = QInputDialog::getText(parent, dialogTitle,
+    QString new_name = QInputDialog::getText(parent ? parent->window() : nullptr,
+                       dialogTitle,
                        prompt,
                        QLineEdit::Normal,
                        defaultNewName,
@@ -260,7 +261,7 @@ _retry:
             goto _retry;
         }
 
-        QMessageBox::critical(parent, QObject::tr("Error"), err.message());
+        QMessageBox::critical(parent ? parent->window() : nullptr, QObject::tr("Error"), err.message());
     }
 }
 

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -45,7 +45,7 @@ LIBFM_QT_API Fm::FilePathList pathListFromQUrls(QList<QUrl> urls);
 
 LIBFM_QT_API std::pair<Fm::FilePathList, bool> parseClipboardData(const QMimeData& data);
 
-LIBFM_QT_API void pasteFilesFromClipboard(const Fm::FilePath& destPath, QWidget* parent = 0);
+LIBFM_QT_API void pasteFilesFromClipboard(const Fm::FilePath& destPath, QWidget* parent = nullptr);
 
 LIBFM_QT_API void copyFilesToClipboard(const Fm::FilePathList& files);
 
@@ -55,7 +55,7 @@ LIBFM_QT_API bool isCurrentPidClipboardData(const QMimeData& data);
 
 LIBFM_QT_API bool changeFileName(const Fm::FilePath& path, const QString& newName, QWidget* parent, bool showMessage = true);
 
-LIBFM_QT_API bool renameFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent = 0);
+LIBFM_QT_API bool renameFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent = nullptr);
 
 enum CreateFileType {
     CreateNewFolder,
@@ -63,7 +63,7 @@ enum CreateFileType {
     CreateWithTemplate
 };
 
-LIBFM_QT_API void createFileOrFolder(CreateFileType type, FilePath parentDir, const TemplateItem* templ = nullptr, QWidget* parent = 0);
+LIBFM_QT_API void createFileOrFolder(CreateFileType type, FilePath parentDir, const TemplateItem* templ = nullptr, QWidget* parent = nullptr);
 
 constexpr uid_t INVALID_UID = uid_t(-1);
 


### PR DESCRIPTION
Closes https://github.com/lxqt/lxqt/issues/1671 as a bonus

Giving window parents to application-modal dialogs is a good practice because they will be centered over their parents when shown -- although the lack of parents should not cause any serious problem either. Some app-modal dialogs already had parents; this patch gives window parents to the rest.

It also prevents KWin from being confused by parentless app-modal dialogs (even Openbox isn't confused by them!).

A small patch for pcmanfm-qt will follow for the sake of completeness.

NOTE: As for KWin, it has yet other problems with parentless app-modal dialogs but, IMO, they aren't our concern. This patch was added only because, by chance, it also made the code more logical.