### PR TITLE
Case-insensitive and match-containing name completer for file dialog

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -58,6 +58,8 @@ FileDialog::FileDialog(QWidget* parent, FilePath path) :
     ui->folderView->setAutoSelectionDelay(0);
     // set the completer
     QCompleter* completer = new QCompleter(this);
+    completer->setCaseSensitivity(Qt::CaseInsensitive);
+    completer->setFilterMode(Qt::MatchContains);
     completer->setModel(proxyModel_);
     ui->fileName->setCompleter(completer);
     connect(completer, static_cast<void(QCompleter::*)(const QString &)>(&QCompleter::activated), [this](const QString &text) {


### PR DESCRIPTION
Closes https://github.com/lxqt/libfm-qt/issues/360

These 2 lines of code make finding of files much easier in LXQt file dialog. IMO, there's no need to more.