### PR TITLE
Add `st` to terminals.list

### DIFF
--- a/data/terminals.list
+++ b/data/terminals.list
@@ -81,6 +81,3 @@ desktop_id=kitty.desktop
 
 [st]
 open_arg=-e
-
-[stterm]
-open_arg=-e

--- a/data/terminals.list
+++ b/data/terminals.list
@@ -78,3 +78,9 @@ desktop_id=termite.desktop
 
 [kitty]
 desktop_id=kitty.desktop
+
+[st]
+open_arg=-e
+
+[stterm]
+open_arg=-e


### PR DESCRIPTION
`st` is the suckless terminal. The executable is `stterm` on Debian-based distros to avoid a conflict with another package.