### PR TITLE
Always respect original order on launching multiple files

### DIFF
--- a/src/core/basicfilelauncher.cpp
+++ b/src/core/basicfilelauncher.cpp
@@ -174,6 +174,7 @@ bool BasicFileLauncher::launchWithApp(GAppInfo* app, const FilePathList& paths, 
         auto uri = path.uri();
         uris = g_list_prepend(uris, uri.release());
     }
+    uris = g_list_reverse(uris);
     GErrorPtr err;
     bool ret = bool(g_app_info_launch_uris(app, uris, ctx, &err));
     g_list_foreach(uris, reinterpret_cast<GFunc>(g_free), nullptr);
@@ -259,6 +260,7 @@ bool BasicFileLauncher::launchDesktopEntry(const char *desktopEntryName, const F
             auto uri = path.uri();
             uris = g_list_prepend(uris, uri.release());
         }
+        uris = g_list_reverse(uris);
         GErrorPtr err;
         ret = bool(fm_app_info_launch(app, uris, ctx, &err));
         g_list_foreach(uris, reinterpret_cast<GFunc>(g_free), nullptr);


### PR DESCRIPTION
This follows https://github.com/lxqt/libfm-qt/commit/442992b38b1c01332cd6b0ecfd56a9fa4f4ad86e, which was for launching from the right click menu. It will have effect when multple launching by presssing `Enter` is implemented (by a future patch in pcmanfm-qt), in which case, it'll respect the sorting/selection order too.

Long story short, after the fast function `g_list_prepend()` is used, `g_list_reverse()` should follow to restore the original order.