### PR TITLE
Prevented a rare random crash in file dialog

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -433,8 +433,11 @@ void FileDialog::selectFilePath(const FilePath &path) {
     QItemSelectionModel* selModel = ui->folderView->selectionModel();
     selModel->select(idx, flags);
     selModel->setCurrentIndex(idx, QItemSelectionModel::Current);
-    QTimer::singleShot(0, this, [this, idx]() {
-        ui->folderView->childView()->scrollTo(idx, QAbstractItemView::PositionAtCenter);
+    QTimer::singleShot(0, this, [this, path]() { // idx should no be captured because dir may change
+        auto idx = proxyModel_->indexFromPath(path);
+        if(idx.isValid()) {
+            ui->folderView->childView()->scrollTo(idx, QAbstractItemView::PositionAtCenter);
+        }
     });
 }
 


### PR DESCRIPTION
On selecting a file path, file dialog also scrolls to it with a single-shot timer and a lambda. Previously, the file index was captured by the lambda but, under very rare circumstances, if the directory had been changed when the slot was called, the index would be irrelevant and so, a crash would happen. This patch captures the file path instead.

Although the crash was rare, sometimes I was able to reproduce it by:

(1) Opening file dialog from FeatherPad or Kate;
(2) Selecting a folder and then a file inside file dialog with `Ctrl` + mouse; and
(3) Pressing `Enter`.