### PR TITLE
Show more info on item tooltip

### DIFF
--- a/src/foldermodel.h
+++ b/src/foldermodel.h
@@ -125,6 +125,9 @@ protected:
     QList<FolderModelItem>::iterator findItemByFileInfo(const Fm::FileInfo* info, int* row);
 
 private:
+    QString makeTooltip(FolderModelItem* item) const;
+
+private:
 
     struct ThumbnailData {
         ThumbnailData(int size):


### PR DESCRIPTION
The info is already fetched by FileInfo. Why not showing it for a better UX?

Closes https://github.com/lxqt/pcmanfm-qt/issues/932 too.