### PR TITLE
Realod folder after transfer job if it lacks file monitoring

### DIFF
--- a/src/core/folder.cpp
+++ b/src/core/folder.cpp
@@ -112,6 +112,20 @@ std::shared_ptr<Folder> Folder::fromPath(const FilePath& path) {
     return folder;
 }
 
+// static
+// Checks if this is the path of a folder in use.
+std::shared_ptr<Folder> Folder::findByPath(const FilePath& path) {
+    std::lock_guard<std::mutex> lock{mutex_};
+    auto it = cache_.find(path);
+    if(it != cache_.end()) {
+        auto folder = it->second.lock();
+        if(folder) {
+            return folder;
+        }
+    }
+    return nullptr;
+}
+
 bool Folder::makeDirectory(const char* /*name*/, GError** /*error*/) {
     // TODO:
     // FIXME: what the API is used for in the original libfm C API?
@@ -140,6 +154,10 @@ std::shared_ptr<const FileInfo> Folder::fileByName(const char* name) const {
 
 bool Folder::isEmpty() const {
     return files_.empty();
+}
+
+bool Folder::hasFileMonitor() const {
+    return (dirMonitor_ != nullptr);
 }
 
 FileInfoList Folder::files() const {

--- a/src/core/folder.h
+++ b/src/core/folder.h
@@ -56,6 +56,8 @@ public:
 
     static std::shared_ptr<Folder> fromPath(const FilePath& path);
 
+    static std::shared_ptr<Folder> findByPath(const FilePath& path);
+
     bool makeDirectory(const char* name, GError** error);
 
     void queryFilesystemInfo();
@@ -73,6 +75,8 @@ public:
     std::shared_ptr<const FileInfo> fileByName(const char* name) const;
 
     bool isEmpty() const;
+
+    bool hasFileMonitor() const;
 
     FileInfoList files() const;
 

--- a/src/fileoperation.cpp
+++ b/src/fileoperation.cpp
@@ -316,6 +316,25 @@ void FileOperation::onJobFinish() {
         }
     }
 
+    // reload the containing folder if it is in use but does not have a file monitor
+    std::shared_ptr<Folder> folder = nullptr;
+    if(type_ == Trash || type_ == Delete
+       || type_ == Move) { // moving may be done to this folder
+        if(!srcPaths_.empty()) {
+            if(auto path = srcPaths_[0]) {
+                if(auto parent_path = path.parent()) {
+                    folder = Fm::Folder::findByPath(parent_path);
+                }
+            }
+        }
+    }
+    if(folder == nullptr && destPath_) {
+        folder = Fm::Folder::findByPath(destPath_);
+    }
+    if(folder && folder->isValid() && folder->isLoaded() && !folder->hasFileMonitor()) {
+        folder->reload();
+    }
+
     if(autoDestroy_) {
         delete this;
     }


### PR DESCRIPTION
Closes https://github.com/lxqt/pcmanfm-qt/issues/933 and closes https://github.com/lxqt/libfm-qt/issues/280

After a file transfer job is finished inside a directory, if it is the path of an open folder that lacks file monitoring, this patch reloads its corresponding folder. In this way, the lack of file monitoring is partially compensated for.

Please note that this doesn't work with `search://` because the files inside `search://` don't belong to it.

WARNING: All libfm-qt based apps should be recompiled after this.