### PR TITLE
Fix editbookmarksdialog

### DIFF
--- a/src/editbookmarksdialog.cpp
+++ b/src/editbookmarksdialog.cpp
@@ -76,6 +76,8 @@ void EditBookmarksDialog::accept() {
             }
             QString name = item->data(0, Qt::DisplayRole).toString();
             QUrl url = QUrl::fromUserInput(item->data(1, Qt::DisplayRole).toString());
+            if (!url.isValid())
+                url = "/";
             file.write(url.toEncoded());
             file.write(" ");
             file.write(name.toUtf8());

--- a/src/editbookmarksdialog.cpp
+++ b/src/editbookmarksdialog.cpp
@@ -90,6 +90,7 @@ void EditBookmarksDialog::accept() {
 void EditBookmarksDialog::onAddItem() {
     QTreeWidgetItem* item = new QTreeWidgetItem();
     item->setData(0, Qt::DisplayRole, tr("New bookmark"));
+    item->setData(1, Qt::DisplayRole, "/");
     item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsDragEnabled | Qt::ItemIsEnabled);
     ui->treeWidget->addTopLevelItem(item);
     ui->treeWidget->editItem(item);


### PR DESCRIPTION
The path variable in new bookmarkitem was previously unitialized (path can be empty when clicking "OK") which creates a non-visible bookmark (for libfm-qt)  which crashes other file managers (which will show a bookmark and a null path).