### PR TITLE
Disable selection corners in single-selection mode

### DIFF
--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -177,17 +177,20 @@ void FolderItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& op
         // Draw select/deselect icons outside the main icon but near its top left corner,
         // with its 1/3 size and only if the icon size isn't smaller than 48 px
         // (otherwise, the user could not click on them easily).
-        if(option.decorationSize.width() >= 48 && opt.state & QStyle::State_MouseOver) {
+        const QAbstractItemView* iv = qobject_cast<const QAbstractItemView*>(opt.widget);
+        if(iv != nullptr
+           // only for the extended and multiple selection modes
+           && (iv->selectionMode() == QAbstractItemView::ExtendedSelection
+               || iv->selectionMode() == QAbstractItemView::MultiSelection)
+           && option.decorationSize.width() >= 48 && (opt.state & QStyle::State_MouseOver)) {
             int s = option.decorationSize.width() / 3;
             bool cursorOnSelectionCorner = false;
             iconPos = QPoint(qMax(opt.rect.x(), iconPos.x() - s),
                              qMax(opt.rect.y(), iconPos.y() - s));
-            if(const QAbstractItemView* iv = qobject_cast<const QAbstractItemView*>(opt.widget)) {
-                QPoint curPos = iv->viewport()->mapFromGlobal(QCursor::pos());
-                if(curPos.x() >= iconPos.x() && curPos.x() <= iconPos.x() + s
-                   && curPos.y() >= iconPos.y() && curPos.y() <= iconPos.y() + s) {
-                    cursorOnSelectionCorner = true;
-                }
+            QPoint curPos = iv->viewport()->mapFromGlobal(QCursor::pos());
+            if(curPos.x() >= iconPos.x() && curPos.x() <= iconPos.x() + s
+               && curPos.y() >= iconPos.y() && curPos.y() <= iconPos.y() + s) {
+                cursorOnSelectionCorner = true;
             }
             if(!cursorOnSelectionCorner) { // make it translucent when not under the cursor
                 painter->save();


### PR DESCRIPTION
Fixes https://github.com/lxqt/libfm-qt/issues/414

For example, in lximage-qt's thumbnail view, selection corners not only caused a wrong behavior but also activated the rubber-band selection. The same was true for LXQt file dialog in the single-selection mode.

This patch enables the selection corners only for extended and multiple selection modes and then treats the extended mode as the default one.

It also disables rubber-band selection in tree-view when the latter is in the single-selection

NOTE: To test this, open lximage-qt's thumbnail view; you should see no selection corner or rubber-band selection but they should remain intact with pcmanfm-qt. Also, the Open File dialog of lximage-qt, for example, should have no selection corner or rubber-band selection because only one file can be selected in it at a time.