### PR TITLE
Row-by-row scrolling inside view when Shift is pressed

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1528,6 +1528,20 @@ bool FolderView::eventFilter(QObject* watched, QEvent* event) {
                     return true;
                 }
             }
+            // row-by-row scrolling when Shift is pressed
+            if (QApplication::keyboardModifiers() & Qt::ShiftModifier)
+            {
+                QScrollBar *sbar = (mode == CompactMode ? view->horizontalScrollBar()
+                                                        : view->verticalScrollBar());
+                if(sbar != nullptr) {
+                    QWheelEvent *we = static_cast<QWheelEvent*>(event);
+                    QWheelEvent e(we->pos(), we->globalPos(),
+                                  we->angleDelta().y() / QApplication::wheelScrollLines(),
+                                  we->buttons(), Qt::NoModifier, Qt::Vertical);
+                    QApplication::sendEvent(sbar, &e);
+                    return true;
+                }
+            }
             // This is to fix #85: Scrolling doesn't work in compact view
             // Actually, I think it's the bug of Qt, not ours.
             // When in compact mode, only the horizontal scroll bar is used and the vertical one is hidden.
@@ -1535,7 +1549,7 @@ bool FolderView::eventFilter(QObject* watched, QEvent* event) {
             // Qt does not implement such a simple feature, unfortunately.
             // We do it by forwarding the scroll event in the viewport to the horizontal scrollbar.
             // FIXME: if someday Qt supports this, we have to disable the workaround.
-            if(mode == CompactMode) {
+            else if(mode == CompactMode) {
                 QScrollBar* scroll = view->horizontalScrollBar();
                 if(scroll) {
                     QApplication::sendEvent(scroll, event);


### PR DESCRIPTION
Some users of Qt apps know that Shift may change wheel scrolling speed. This patch makes the view scroll row-by-row with the mouse wheel when Shift is pressed and the cursor is inside the view.

Of course, in the compact view, Shift wheel scrolling is done column-by-column.

When the cursor is on the scrollbar, Qt's default behavior is left intact, i.e. the scroll is faster with Shift. Although I don't think users of a file manager need that, I didn't add extra code to change it.

NOTE: The arguments of `QWheelEvent` have changed recently. I used the old constructor to not break the compilation with older Qt versions but we should really bump the minimum version.