### PR TITLE
File dialog: Smarter extension handling on saving

### DIFF
--- a/src/filedialog.h
+++ b/src/filedialog.h
@@ -181,6 +181,7 @@ private:
     void onFileInfoJobFinished();
     void freeFolder();
     QStringList parseNames() const;
+    QString suffix(bool checkDefaultSuffix = true) const;
 
 private:
     std::unique_ptr<Ui::FileDialog> ui;


### PR DESCRIPTION
Closes https://github.com/lxqt/libfm-qt/issues/421 and closes https://github.com/lxqt/libfm-qt/issues/423 and fixes https://github.com/lxqt/lxqt-archiver/issues/29

This is how extensions are handled in the save mode:

 * If the file name has no extension and there isn't a default suffix but there is a filter in "File type" combo — like `Image Files (*.png *.jpg)` — the first extension provided by the filter will be added to the saved file name.
 * If the file name has an extension and the contents of "File type" combo is changed by the user, the extension will be updated accordingly.
 * Filters like `NAME (DESCRIPTION) (*.X *.Y)` are covered.

Overwrite prompts are also handled appropriately.

NOTE: Recompile libfm-qt based apps after this.