### PR TITLE
Added deletion time to Trash

### DIFF
--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -10,6 +10,7 @@ const char defaultGFileInfoQueryAttribs[] = "standard::*,"
                                             "unix::*,"
                                             "time::*,"
                                             "access::*,"
+                                            "trash::deletion-date,"
                                             "id::filesystem,"
                                             "metadata::emblems,"
                                             METADATA_TRUST;
@@ -261,6 +262,12 @@ _file_is_symlink:
     mtime_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_TIME_MODIFIED);
     atime_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_TIME_ACCESS);
     ctime_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_TIME_CHANGED);
+    if(auto dt = g_file_info_get_deletion_date(inf.get())){
+        dtime_ = g_date_time_to_unix(dt);
+    }
+    else {
+        dtime_ = 0;
+    }
     isHidden_ = g_file_info_get_is_hidden(inf.get());
     // g_file_info_get_is_backup() does not cover ".bak" and ".old".
     // NOTE: Here, dispName_ is not modified for desktop entries yet.

--- a/src/core/fileinfo.h
+++ b/src/core/fileinfo.h
@@ -102,6 +102,9 @@ public:
         return mtime_;
     }
 
+    quint64 dtime() const {
+        return dtime_;
+    }
     const std::string& target() const {
         return target_;
     }
@@ -233,6 +236,7 @@ private:
     quint64 mtime_;
     quint64 atime_;
     quint64 ctime_;
+    quint64 dtime_;
 
     uint64_t blksize_;
     uint64_t blocks_;

--- a/src/foldermenu.cpp
+++ b/src/foldermenu.cpp
@@ -161,6 +161,11 @@ void FolderMenu::createSortMenu() {
 
     addSortMenuItem(tr("By File Name"), FolderModel::ColumnFileName);
     addSortMenuItem(tr("By Modification Time"), FolderModel::ColumnFileMTime);
+    if(auto folderPath = view_->path()) {
+        if(strcmp(folderPath.toString().get(), "trash:///") == 0) {
+            addSortMenuItem(tr("By Deletion Time"), FolderModel::ColumnFileDTime);
+        }
+    }
     addSortMenuItem(tr("By File Size"), FolderModel::ColumnFileSize);
     addSortMenuItem(tr("By File Type"), FolderModel::ColumnFileType);
     addSortMenuItem(tr("By File Owner"), FolderModel::ColumnFileOwner);

--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -267,6 +267,8 @@ QVariant FolderModel::data(const QModelIndex& index, int role/* = Qt::DisplayRol
             return QString::fromUtf8(info->mimeType()->desc());
         case ColumnFileMTime:
             return item->displayMtime();
+        case ColumnFileDTime:
+            return item->displayDtime();
         case ColumnFileSize:
             return item->displaySize();
         case ColumnFileOwner:
@@ -314,6 +316,9 @@ QVariant FolderModel::headerData(int section, Qt::Orientation orientation, int r
                 break;
             case ColumnFileMTime:
                 title = tr("Modified");
+                break;
+            case ColumnFileDTime:
+                title = tr("Deleted");
                 break;
             case ColumnFileOwner:
                 title = tr("Owner");

--- a/src/foldermodel.h
+++ b/src/foldermodel.h
@@ -52,6 +52,7 @@ public:
         ColumnFileType,
         ColumnFileSize,
         ColumnFileMTime,
+        ColumnFileDTime,
         ColumnFileOwner,
         ColumnFileGroup,
         NumOfColumns

--- a/src/foldermodelitem.cpp
+++ b/src/foldermodelitem.cpp
@@ -61,6 +61,14 @@ const QString &FolderModelItem::displayMtime() const {
     return dispMtime_;
 }
 
+const QString &FolderModelItem::displayDtime() const {
+    if(dispDtime_.isEmpty() && info->dtime() > 0) {
+        auto mtime = QDateTime::fromMSecsSinceEpoch(info->dtime() * 1000);
+        dispDtime_ = mtime.toString(Qt::SystemLocaleShortDate);
+    }
+    return dispDtime_;
+}
+
 const QString& FolderModelItem::displaySize() const {
     if(!info->isDir()) {
         // FIXME: choose IEC or SI units

--- a/src/foldermodelitem.h
+++ b/src/foldermodelitem.h
@@ -72,6 +72,8 @@ public:
 
     const QString& displayMtime() const;
 
+    const QString& displayDtime() const;
+
     const QString &displaySize() const;
 
     bool isCut() const;
@@ -84,6 +86,7 @@ public:
 
     std::shared_ptr<const Fm::FileInfo> info;
     mutable QString dispMtime_;
+    mutable QString dispDtime_;
     mutable QString dispSize_;
     std::weak_ptr<const HashSet> cutFilesHashSet_;
     QVector<Thumbnail> thumbnails;

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -367,9 +367,22 @@ void FolderViewTreeView::headerContextMenu(const QPoint &p) {
         menu.addAction (labelAction);
 
         int filenameColumn = header()->visualIndex(FolderModel::ColumnFileName);
+        int dTimeColumn = header()->visualIndex(FolderModel::ColumnFileDTime);
+        bool isTrash = false;
+        if(ProxyFolderModel* proxyModel = qobject_cast<ProxyFolderModel*>(model())) {
+            if(auto model = static_cast<FolderModel*>(proxyModel->sourceModel())) {
+                if(model->path() && strcmp(model->path().toString().get(), "trash:///") == 0) {
+                    isTrash = true;
+                }
+            }
+        }
         int numCols = header()->count();
         for(int column = 0; column < numCols; ++column) {
             int columnId = header()->logicalIndex(column);
+            if(!isTrash && columnId == dTimeColumn) {
+                // no action for the deletion time column if this isn't trash
+                continue;
+            }
             if(columnId >= 0 && columnId < FolderModel::NumOfColumns) {
                 action = menu.addAction (model()->headerData(columnId, Qt::Horizontal, Qt::DisplayRole).toString());
                 action->setCheckable(true);
@@ -568,9 +581,24 @@ void FolderViewTreeView::layoutColumns() {
         }
         QAbstractItemModel* model_ = model();
         int filenameColumn = headerView->visualIndex(FolderModel::ColumnFileName);
+        int dTimeColumn = header()->visualIndex(FolderModel::ColumnFileDTime);
+        bool isTrash = false;
+        if(ProxyFolderModel* proxyModel = qobject_cast<ProxyFolderModel*>(model())) {
+            if(auto model = static_cast<FolderModel*>(proxyModel->sourceModel())) {
+                if(model->path() && strcmp(model->path().toString().get(), "trash:///") == 0) {
+                    isTrash = true;
+                }
+            }
+        }
         int column;
         for(column = 0; column < numCols; ++column) {
             int columnId = headerView->logicalIndex(column);
+
+            if(!isTrash && columnId == dTimeColumn) {
+                // hide the deletion time column if this isn't trash
+                headerView->setSectionHidden(columnId, true);
+                continue;
+            }
 
             // handle hidden columns
             bool wasHidden = false;


### PR DESCRIPTION
Outside Trash, the deletion column and sort action are hidden/removed because the column is empty and, if sorting is done by deletion inside Trash, it will be by file name outside it. That's unlike Dolphin, which shows a redundant empty column outside Trash.

NOTE: pcmanfm-qt should be recompiled, preferably with the patch that will follow this for a complete implementation.