### PR TITLE
Completed the thumbnail transformations based on EXIF

### DIFF
--- a/src/core/thumbnailjob.h
+++ b/src/core/thumbnailjob.h
@@ -1,4 +1,4 @@
-﻿#ifndef FM2_THUMBNAILJOB_H
+#ifndef FM2_THUMBNAILJOB_H
 #define FM2_THUMBNAILJOB_H
 
 #include "../libfmqtglobals.h"
@@ -58,7 +58,7 @@ private:
 
     QImage loadForFile(const std::shared_ptr<const FileInfo>& file);
 
-    bool readJpegExif(GInputStream* stream, QImage& thumbnail, int& rotate_degrees);
+    bool readJpegExif(GInputStream* stream, QImage& thumbnail, QMatrix& matrix);
 
 private:
     FileInfoList files_;


### PR DESCRIPTION
The transformations are done by a `QMatrix`, based on EXIF orientations table (see, for example, https://sno.phy.queensu.ca/~phil/exiftool/TagNames/EXIF.html):

1 = Nothing
2 = Flip horizontal
3 = Rotate 180 CW
4 = Flip vertical
5 = Transpose (Mirror horizontal and rotate 270 CW)
6 = Rotate 90 CW
7 = Transverse (Mirror horizontal and rotate 90 CW)
8 = Rotate 270 CW