### PR TITLE
Don't start item DND until the cursor is really moved

### DIFF
--- a/src/folderview_p.h
+++ b/src/folderview_p.h
@@ -77,6 +77,7 @@ private Q_SLOTS:
 private:
   bool activationAllowed_;
   mutable bool cursorOnSelectionCorner_;
+  QPoint globalItemPressPoint_; // to prevent dragging when only the view is scrolled
 };
 
 class FolderViewTreeView : public QTreeView {
@@ -133,6 +134,9 @@ private:
   bool activationAllowed_;
   QList<int> customColumnWidths_;
   QSet<int> hiddenColumns_;
+  QPoint globalItemPressPoint_; // to prevent dragging when only the view is scrolled
+
+  // for rubberband
   QPoint mousePressPoint_;
   QRect rubberBandRect_;
   QItemSelectionModel::SelectionFlag ctrlDragSelectionFlag_;


### PR DESCRIPTION
Closes https://github.com/lxqt/pcmanfm-qt/issues/976

Qt considers the cursor position relative to the view to determine whether a DND should start, so that, even when the cursor isn't moved, the DND will start if the view is scrolled (by mouse wheel).

However, the user may want to press the left mouse button on an item and scroll the view with mouse wheel before starting DND. This patch makes that possible by preventing a DND until the global cursor position is changed.

NOTE: Cursor position relative to the window might also work but the global position seems good (for now).