### PR TITLE
Update rubberband selection with smooth scrolling

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -82,7 +82,12 @@ void FolderViewListView::startDrag(Qt::DropActions supportedActions) {
 
 void FolderViewListView::mousePressEvent(QMouseEvent* event) {
     if(event->buttons() == Qt::LeftButton) { // see FolderViewListView::mouseMoveEvent
-        globalItemPressPoint_ = event->globalPos();
+        if(indexAt(event->pos()).isValid()) {
+            globalItemPressPoint_ = event->globalPos();
+        }
+        else {
+            globalItemPressPoint_ = QPoint();
+        }
     }
     // switch between the extended and multiple selection modes,
     // depending on the cursor position, only when there's no other mode
@@ -1684,6 +1689,16 @@ void FolderView::scrollSmoothly() {
                       wheelEvent_->buttons(), Qt::NoModifier, Qt::Vertical);
         QApplication::sendEvent(view->verticalScrollBar(), &e);
     }
+
+    // update rubberband selection with smooth scrolling
+    if (QApplication::mouseButtons() & Qt::LeftButton) {
+        const QPoint globalPos = QCursor::pos();
+        QPoint pos = view->viewport()->mapFromGlobal(globalPos);
+        QMouseEvent ev(QEvent::MouseMove, pos, view->viewport()->mapTo(view->viewport()->topLevelWidget(), pos), globalPos,
+                       Qt::LeftButton, Qt::LeftButton, QApplication::keyboardModifiers());
+        QApplication::sendEvent(view->viewport(), &ev);
+    }
+
     if(queuedScrollSteps_.empty()) {
         smoothScrollTimer_->stop();
     }


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/978

This patch fixes the following minor issue by sending a mouse move event to the viewport after each smooth scroll:

 (1) In a folder with many files, select a few at the top by pressing the left mouse button and dragging the cursor over them but, after that, do not release the left mouse button;
 (2) While the cursor is motionless and the left mouse button is still pressed, turn the mouse wheel so that the view is scrolled down.

Previously, the selection wasn't updated correctly.