### PR TITLE
Easier and richer auto-completion

### DIFF
--- a/src/pathedit.h
+++ b/src/pathedit.h
@@ -48,7 +48,7 @@ private Q_SLOTS:
     void onTextEdited(const QString& text);
 
 private:
-    void autoComplete();
+    void selectNextCompletionRow(bool downward);
     void reloadCompleter(bool triggeredByFocusInEvent = false);
     void freeCompleter();
     void onJobFinished();
@@ -58,6 +58,7 @@ private:
     QStringListModel* model_;
     QString currentPrefix_;
     GCancellable* cancellable_;
+    QString lastTypedText_;
 };
 
 }


### PR DESCRIPTION
Closes https://github.com/lxqt/pcmanfm-qt/issues/201

Auto-completion always results in a path that ends with a slash. If an auto-completion has only one result, `Tab` will select it and open the next auto-completion popup (if any). Otherwise, Tab will select the next match on the popup.

When the popup is visible, pressing `Escape` not only closes it but also restores the last typed text.

`Backtab` is treated like `Tab` but for selecting the previous match.

To improve performance, matches are ordered alphabetically (see Qt doc).

As before, directory change requires pressing `Enter/Return`; `Tab` only puts the text into the path-bar.

NOTE: I tried to make it as logical as possible and it became very similar to what Dolphin did — but not identical because, in pcmanfm-qt, applying the path gives the focus to the main view. I think users could easily grasp it.