### PR TITLE
Cleanup

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1102,9 +1102,7 @@ void FolderView::setViewMode(ViewMode _mode) {
         view->setDragDropMode(QAbstractItemView::DragDrop);
 
         // inline renaming
-        if(delegate) {
-            connect(delegate, &QAbstractItemDelegate::closeEditor, this, &FolderView::onClosingEditor);
-        }
+        connect(delegate, &QAbstractItemDelegate::closeEditor, this, &FolderView::onClosingEditor);
 
         if(model_) {
             // FIXME: preserve selections


### PR DESCRIPTION
There is no sense in testing the 'delegate' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error.