### PR TITLE
Corrected lxqt-archiver's mimetypes and added arqiver to archivers list

### DIFF
--- a/data/archivers.list
+++ b/data/archivers.list
@@ -2,7 +2,14 @@
 create=lxqt-archiver --add %U
 extract=lxqt-archiver --extract %U
 extract_to=lxqt-archiver --extract-to %d %U
-mime_types=application/x-7z-compressed;application/x-7z-compressed-tar;application/x-ace;application/x-alz;application/x-ar;application/x-arj;application/x-bzip;application/x-bzip-compressed-tar;application/x-bzip1;application/x-bzip1-compressed-tar;application/x-cabinet;application/x-cbr;application/x-cbz;application/x-cd-image;application/x-compress;application/x-compressed-tar;application/x-cpio;application/x-deb;application/x-ear;application/x-ms-dos-executable;application/x-gtar;application/x-gzip;application/x-gzpostscript;application/x-java-archive;application/x-lha;application/x-lhz;application/x-lzip;application/x-lzip-compressed-tar;application/x-lzma;application/x-lzma-compressed-tar;application/x-lzop;application/x-lzop-compressed-tar;application/x-rar;application/x-rar-compressed;application/vnd.rar;application/x-rpm;application/x-rzip;application/x-tar;application/x-tarz;application/x-stuffit;application/x-war;application/x-xz;application/x-xz-compressed-tar;application/x-zip;application/x-zip-compressed;application/x-zoo;application/zip;multipart/x-zip;
+mime_types=application/x-7z-compressed;application/x-7z-compressed-tar;application/x-ace;application/x-alz;application/x-ar;application/x-arj;application/x-bzip;application/x-bzip-compressed-tar;application/x-bzip1;application/x-bzip1-compressed-tar;application/x-cabinet;application/x-cbr;application/x-cbz;application/x-cd-image;application/x-compress;application/x-compressed-tar;application/x-cpio;application/x-deb;application/vnd.debian.binary-package;application/x-ear;application/x-ms-dos-executable;application/x-gtar;application/x-gzip;application/x-gzpostscript;application/x-java-archive;application/x-lha;application/x-lhz;application/x-lzip;application/x-lzip-compressed-tar;application/x-lzma;application/x-lzma-compressed-tar;application/x-lzop;application/x-lzop-compressed-tar;application/x-rar;application/x-rar-compressed;application/vnd.rar;application/x-rpm;application/x-rzip;application/x-tar;application/x-tarz;application/x-stuffit;application/x-war;application/x-xz;application/x-xz-compressed-tar;application/x-zip;application/x-zip-compressed;application/x-zoo;application/zip;application/gzip;multipart/x-zip;
+supports_uris=true
+
+[arqiver]
+create=arqiver --sa %U
+extract=arqiver --sx %U
+extract_to=arqiver --ax %U
+mime_types=application/x-xz-compressed-tar;application/x-lzma-compressed-tar;application/x-bzip-compressed-tar;application/x-bzip;application/x-tar;application/x-compressed-tar;application/zip;application/gzip;image/svg+xml-compressed;application/x-gzpdf;application/bzip;application/x-7z-compressed;application/vnd.debian.binary-package;application/x-archive;application/x-cpio;application/x-rpm;application/x-source-rpm;application/x-cd-image;application/x-raw-disk-image;application/x-xar;application/x-java-archive;
 supports_uris=true
 
 [file-roller]


### PR DESCRIPTION
Closes https://github.com/lxqt/libfm-qt/issues/453 and closes https://github.com/lxqt/libfm-qt/issues/268

"application/gzip" was missing in lxqt-archiver mimetypes. Also Arqiver is added after lxqt-archiver because it works fine with libfm-qt.