### PR TITLE
Don't show "untrust" emblem where it isn't needed

### DIFF
--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -405,8 +405,9 @@ bool FileInfo::isTrustable() const {
                 return (strcmp(data, "true") == 0);
             }
         }
+        return false;
     }
-    return false;
+    return true;
 }
 
 void FileInfo::setTrustable(bool trust) const {

--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -32,6 +32,7 @@
 #include <QLineEdit>
 #include <QTextEdit>
 #include <QTimer>
+#include <QStandardPaths>
 #include <QDebug>
 
 namespace Fm {
@@ -129,8 +130,14 @@ void FolderItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& op
 
     bool isSymlink = file && file->isSymlink();
     bool isCut = index.data(FolderModel::FileIsCutRole).toBool();
-    // for practical reasons, an emblem is added only to an untrusted, deletable desktop file
+    // an emblem is added only to an untrusted, deletable desktop file that isn't inside applications directory
     bool untrusted = file && !file->isTrustable() && file->isDesktopEntry() && file->isDeletable();
+    if(untrusted) {
+        auto parentDir = QString::fromUtf8((file->dirPath().toString().get()));
+        if(QStandardPaths::standardLocations(QStandardPaths::ApplicationsLocation).contains(parentDir)) {
+            untrusted = false;
+        }
+    }
     // vertical layout (icon mode, thumbnail mode)
     if(option.decorationPosition == QStyleOptionViewItem::Top ||
             option.decorationPosition == QStyleOptionViewItem::Bottom) {


### PR DESCRIPTION
Don't show "untrust" emblem where it isn't needed

The patch does two things:

 1. It fixes the logic of "trust" and trusts all non-executable files. As a result, desktop entries inside `menu://applications/` or Trash don't have emblems anymore.

 2. It removes the "untrust" emblem from desktop entries inside `~/.local/share/applications` (as Dolphin does), although they aren't trusted by default (like in `/usr/share/applications`).