### PR TITLE
Wait: Fixed problems in graying-out of cut files

### DIFF
--- a/src/core/fileinfo.h
+++ b/src/core/fileinfo.h
@@ -220,6 +220,10 @@ public:
 
     void setTrustable(bool trust) const;
 
+    GObjectPtr<GFileInfo> gFileInfo() const {
+        return inf_;
+    }
+
 private:
     GObjectPtr<GFileInfo> inf_;
     std::string name_;

--- a/src/core/folder.h
+++ b/src/core/folder.h
@@ -84,11 +84,11 @@ public:
 
     const std::shared_ptr<const FileInfo> &info() const;
 
-    bool hadCutFilesUnset();
-
-    bool hasCutFiles();
-
     void setCutFiles(const std::shared_ptr<const HashSet>& cutFilesHashSet);
+    bool hasCutFiles() const;
+    bool hadCutFiles();
+
+    void updateCutFiles();
 
     void forEachFile(std::function<void (const std::shared_ptr<const FileInfo>&)> func) const {
         std::lock_guard<std::mutex> lock{mutex_};
@@ -105,6 +105,8 @@ Q_SIGNALS:
     void filesAdded(FileInfoList& addedFiles);
 
     void filesChanged(std::vector<FileInfoPair>& changePairs);
+
+    void cutFilesChanged(std::vector<FileInfoPair>& changePairs);
 
     void filesRemoved(FileInfoList& removedFiles);
 

--- a/src/foldermodel.h
+++ b/src/foldermodel.h
@@ -94,8 +94,6 @@ public:
     void cacheThumbnails(int size);
     void releaseThumbnails(int size);
 
-    void setCutFiles(const QItemSelection& selection);
-
     void setShowFullName(bool fullName) {
         showFullNames_ = fullName;
     }
@@ -111,11 +109,14 @@ protected Q_SLOTS:
     void onFinishLoading();
     void onFilesAdded(const Fm::FileInfoList& files);
     void onFilesChanged(std::vector<Fm::FileInfoPair>& files);
+    void onCutFilesChanged(std::vector<Fm::FileInfoPair>& files);
     void onFilesRemoved(const Fm::FileInfoList& files);
 
     void onThumbnailLoaded(const std::shared_ptr<const Fm::FileInfo>& file, int size, const QImage& image);
     void onThumbnailJobFinished();
     void loadPendingThumbnails();
+
+    void onClipboardDataChange();
 
 protected:
     void queueLoadThumbnail(const std::shared_ptr<const Fm::FileInfo>& file, int size);
@@ -126,6 +127,7 @@ protected:
     QList<FolderModelItem>::iterator findItemByFileInfo(const Fm::FileInfo* info, int* row);
 
 private:
+    void setCutFiles(const Fm::FilePathList& paths);
     QString makeTooltip(FolderModelItem* item) const;
 
 private:

--- a/src/foldermodelitem.cpp
+++ b/src/foldermodelitem.cpp
@@ -78,11 +78,7 @@ const QString& FolderModelItem::displaySize() const {
 }
 
 bool FolderModelItem::isCut() const {
-    return !cutFilesHashSet_.expired() || info->isCut();
-}
-
-void FolderModelItem::bindCutFiles(const std::shared_ptr<const HashSet>& cutFilesHashSet) {
-    cutFilesHashSet_ = cutFilesHashSet;
+    return info->isCut();
 }
 
 // find thumbnail of the specified size

--- a/src/foldermodelitem.h
+++ b/src/foldermodelitem.h
@@ -78,8 +78,6 @@ public:
 
     bool isCut() const;
 
-    void bindCutFiles(const std::shared_ptr<const HashSet>& cutFilesHashSet);
-
     Thumbnail* findThumbnail(int size, bool transparent);
 
     void removeThumbnail(int size);
@@ -88,7 +86,6 @@ public:
     mutable QString dispMtime_;
     mutable QString dispDtime_;
     mutable QString dispSize_;
-    std::weak_ptr<const HashSet> cutFilesHashSet_;
     QVector<Thumbnail> thumbnails;
 };
 

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -840,7 +840,6 @@ FolderView::FolderView(FolderView::ViewMode _mode, QWidget *parent):
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     connect(this, &FolderView::clicked, this, &FolderView::onFileClicked);
-    connect(QApplication::clipboard(), &QClipboard::dataChanged, this, &FolderView::onClipboardDataChange);
 }
 
 FolderView::~FolderView() {
@@ -1818,35 +1817,6 @@ void FolderView::onFileClicked(int type, const std::shared_ptr<const Fm::FileInf
         if(menu) {
             menu->exec(QCursor::pos());
             delete menu;
-        }
-    }
-}
-
-void FolderView::onClipboardDataChange() {
-    if(model_) {
-        const QClipboard* clipboard = QApplication::clipboard();
-        const QMimeData* data = clipboard->mimeData();
-        Fm::FilePathList paths;
-        bool isCutSelection;
-        std::tie(paths, isCutSelection) = Fm::parseClipboardData(*data);
-        if(!folder()->path().hasUriScheme("search") // skip for search results
-           && isCutSelection
-           && Fm::isCurrentPidClipboardData(*data)) { // set cut files only with this app
-            auto cutDirPath = paths.size() > 0 ? paths[0].parent() : FilePath();
-            // set the cut file(s) only if the cutting is done here
-            if(folder()->path() == cutDirPath
-               && selectedFilePaths() == paths) {
-                model_->setCutFiles(selectionModel()->selection());
-            }
-            else if(folder()->hadCutFilesUnset() || folder()->hasCutFiles()) {
-                model_->setCutFiles(QItemSelection());
-            }
-            return;
-        }
-
-        folder()->setCutFiles(std::make_shared<HashSet>()); // clean Folder::cutFilesHashSet_
-        if(folder()->hadCutFilesUnset()) {
-            model_->setCutFiles(QItemSelection()); // update indexes if there were cut files here
         }
     }
 }

--- a/src/folderview.h
+++ b/src/folderview.h
@@ -165,7 +165,6 @@ public Q_SLOTS:
     void onItemActivated(QModelIndex index);
     void onSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
     virtual void onFileClicked(int type, const std::shared_ptr<const Fm::FileInfo>& fileInfo);
-    void onClipboardDataChange();
 
 private Q_SLOTS:
     void onAutoSelectionTimeout();

--- a/src/proxyfoldermodel.cpp
+++ b/src/proxyfoldermodel.cpp
@@ -212,13 +212,6 @@ std::shared_ptr<const FileInfo> ProxyFolderModel::fileInfoFromPath(const FilePat
     return fileInfoFromIndex(indexFromPath(path));
 }
 
-void ProxyFolderModel::setCutFiles(const QItemSelection& selection) {
-    FolderModel* srcModel = static_cast<FolderModel*>(sourceModel());
-    if(srcModel) {
-        srcModel->setCutFiles(mapSelectionToSource(selection));
-    }
-}
-
 void ProxyFolderModel::setShowThumbnails(bool show) {
     if(show != showThumbnails_) {
         showThumbnails_ = show;

--- a/src/proxyfoldermodel.h
+++ b/src/proxyfoldermodel.h
@@ -68,8 +68,6 @@ public:
 
     void setSortCaseSensitivity(Qt::CaseSensitivity cs);
 
-    void setCutFiles(const QItemSelection& selection);
-
     bool showThumbnails() {
         return showThumbnails_;
     }

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -117,11 +117,8 @@ void pasteFilesFromClipboard(const Fm::FilePath& destPath, QWidget* parent) {
 void copyFilesToClipboard(const Fm::FilePathList& files) {
     QClipboard* clipboard = QApplication::clipboard();
     QMimeData* data = new QMimeData();
-    QByteArray ba;
     auto urilist = pathListToUriList(files);
 
-    // Add current pid to trace cut/copy operations to current app
-    data->setData(QStringLiteral("text/x-libfmqt-pid"), ba.setNum(QCoreApplication::applicationPid()));
     // Gnome, LXDE, and XFCE
     // Note: the standard text/urilist format uses CRLF for line breaks, but gnome format uses LF only
     data->setData(QStringLiteral("x-special/gnome-copied-files"), QByteArray("copy\n") + urilist.replace("\r\n", "\n"));
@@ -134,11 +131,8 @@ void copyFilesToClipboard(const Fm::FilePathList& files) {
 void cutFilesToClipboard(const Fm::FilePathList& files) {
     QClipboard* clipboard = QApplication::clipboard();
     QMimeData* data = new QMimeData();
-    QByteArray ba;
     auto urilist = pathListToUriList(files);
 
-    // Add current pid to trace cut/copy operations to current app
-    data->setData(QStringLiteral("text/x-libfmqt-pid"), ba.setNum(QCoreApplication::applicationPid()));
     // Gnome, LXDE, and XFCE
     // Note: the standard text/urilist format uses CRLF for line breaks, but gnome format uses LF only
     data->setData(QStringLiteral("x-special/gnome-copied-files"), QByteArray("cut\n") + urilist.replace("\r\n", "\n"));
@@ -146,14 +140,6 @@ void cutFilesToClipboard(const Fm::FilePathList& files) {
     data->setData(QStringLiteral("text/uri-list"), urilist);
     data->setData(QStringLiteral("application/x-kde-cutselection"), QByteArrayLiteral("1"));
     clipboard->setMimeData(data);
-}
-
-bool isCurrentPidClipboardData(const QMimeData& data) {
-    QByteArray clip_pid = data.data(QStringLiteral("text/x-libfmqt-pid"));
-    QByteArray curr_pid;
-    curr_pid.setNum(QCoreApplication::applicationPid());
-
-    return !clip_pid.isEmpty() && clip_pid == curr_pid;
 }
 
 bool changeFileName(const Fm::FilePath& filePath, const QString& newName, QWidget* parent, bool showMessage) {

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -51,8 +51,6 @@ LIBFM_QT_API void copyFilesToClipboard(const Fm::FilePathList& files);
 
 LIBFM_QT_API void cutFilesToClipboard(const Fm::FilePathList& files);
 
-LIBFM_QT_API bool isCurrentPidClipboardData(const QMimeData& data);
-
 LIBFM_QT_API bool changeFileName(const Fm::FilePath& path, const QString& newName, QWidget* parent, bool showMessage = true);
 
 LIBFM_QT_API bool renameFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent = nullptr);


### PR DESCRIPTION
Fixes https://github.com/lxqt/libfm-qt/issues/457

Cut files are grayed out almost instantly once the signal `QClipboard::dataChanged` is emitted, even when their number is huge or they're cut by another app (based on libfm-qt or not).

The structure of the graying-out code is simplified, so that its process is started in `Fm::FolderModel` by connecting to `QClipboard::dataChanged` but the necessary updates are done by `Fm::Folder::updateCutFiles()`, which is very fast.

Please note that, when cutting is done in *another* app, `QClipboard::dataChanged` isn't always reliable: the signal may be emitted with a delay or may not be emitted until the cursor enters the window. That's a Qt issue and is especially visible in Qt 5.13 but it isn't so important for us because we want it to work with different folder models of the same app.

**NOTE:** All libfm-qt based apps should be recompiled.

P.S. IMO, this can wait until 0.15 is released.