### PR TITLE
Fixed a mistake in putting cursor over files

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -146,10 +146,10 @@ QModelIndex FolderViewListView::indexAt(const QPoint& point) const {
            && (selectionMode() == QAbstractItemView::ExtendedSelection
                || selectionMode() == QAbstractItemView::MultiSelection)) {
             int s = _iconSize.width() / 3;
-            iconLeft = qMax(visRect.left(), iconLeft - s);
-            iconTop = qMax(visRect.top(), iconTop - s);
-            if(point.x() >= iconLeft &&  point.x() <= iconLeft + s
-               && point.y() >= iconTop &&  point.y() <= iconTop + s) {
+            int icnLeft = qMax(visRect.left(), iconLeft - s);
+            int icnTop = qMax(visRect.top(), iconTop - s);
+            if(point.x() >= icnLeft &&  point.x() <= icnLeft + s
+               && point.y() >= icnTop &&  point.y() <= icnTop + s) {
                 cursorOnSelectionCorner_ = true;
                 return index;
             }


### PR DESCRIPTION
Two variables were changed inside a block, although they were needed outside it. The problem caused by this mistake wasn't big: an item could sometimes be selected/activated by clicking inside a small empty space at the left side of its icon.