### PR TITLE
Fixed a crash in renaming bookmark with dot in its name

### DIFF
--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -486,7 +486,7 @@ void FolderItemDelegate::setEditorData(QWidget* editor, const QModelIndex& index
             /* Qt will call QLineEdit::selectAll() after calling setEditorData() in
                qabstractitemview.cpp -> QAbstractItemViewPrivate::editor(). Therefore,
                we cannot select a part of the text in the usual way here.  */
-            QTimer::singleShot(0, [lineEdit]() {
+            QTimer::singleShot(0, lineEdit, [lineEdit]() {
                 int length = lineEdit->text().lastIndexOf(QLatin1String("."));
                 lineEdit->setSelection(0, length);
             });


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/1009

The context object was missing in a lambda connection.