### PR TITLE
File dialog: Fixed lack of overwrite prompt in some cases

### DIFF
--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -411,22 +411,16 @@ Qt::ItemFlags FolderModel::flags(const QModelIndex& index) const {
     return flags;
 }
 
-// FIXME: this is very inefficient and should be replaced with a
-// more reasonable implementation later.
-QList<FolderModelItem>::iterator FolderModel::findItemByPath(const Fm::FilePath& path, int* row) {
-    QList<FolderModelItem>::iterator it = items.begin();
-    int i = 0;
+std::shared_ptr<const Fm::FileInfo> FolderModel::fileInfoFromPath(const Fm::FilePath& path) const {
+    QList<FolderModelItem>::const_iterator it = items.begin();
     while(it != items.end()) {
-        FolderModelItem& item = *it;
-        auto item_path = item.info->path();
-        if(item_path == path) {
-            *row = i;
-            return it;
+        const FolderModelItem& item = *it;
+        if(item.info->path() == path) {
+            return item.info;
         }
         ++it;
-        ++i;
     }
-    return items.end();
+    return nullptr;
 }
 
 // FIXME: this is very inefficient and should be replaced with a

--- a/src/foldermodel.h
+++ b/src/foldermodel.h
@@ -88,6 +88,7 @@ public:
     bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent) override;
 
     std::shared_ptr<const Fm::FileInfo> fileInfoFromIndex(const QModelIndex& index) const;
+    std::shared_ptr<const Fm::FileInfo> fileInfoFromPath(const Fm::FilePath& path) const;
     FolderModelItem* itemFromIndex(const QModelIndex& index) const;
     QImage thumbnailFromIndex(const QModelIndex& index, int size);
 
@@ -122,7 +123,6 @@ protected:
     void queueLoadThumbnail(const std::shared_ptr<const Fm::FileInfo>& file, int size);
     void insertFiles(int row, const Fm::FileInfoList& files);
     void removeAll();
-    QList<FolderModelItem>::iterator findItemByPath(const Fm::FilePath& path, int* row);
     QList<FolderModelItem>::iterator findItemByName(const char* name, int* row);
     QList<FolderModelItem>::iterator findItemByFileInfo(const Fm::FileInfo* info, int* row);
 


### PR DESCRIPTION
Fixes https://github.com/lxqt/libfm-qt/issues/467

Previously, when a file existed but was filtered out by the file dialog, there was no overwrite prompt on saving.

Also, a minor problem is fixed in automatic file saving suffixes.

NOTE: All libfm-qt based apps should be recompiled after this.