### PR TITLE
Fixed a potential cause of crash in showing errors

### DIFF
--- a/src/filelauncher.cpp
+++ b/src/filelauncher.cpp
@@ -77,6 +77,9 @@ bool FileLauncher::openFolder(GAppLaunchContext *ctx, const FileInfoList &folder
 }
 
 bool FileLauncher::showError(GAppLaunchContext* /*ctx*/, const GErrorPtr &err, const FilePath &path, const FileInfoPtr &info) {
+    if(err == nullptr) {
+        return false;
+    }
     /* ask for mount if trying to launch unmounted path */
     if(err->domain == G_IO_ERROR) {
         if(path && err->code == G_IO_ERROR_NOT_MOUNTED) {


### PR DESCRIPTION
The crash could happen with a null pointer for error, which was possible when canceling the app chooser dialog — I could reproduce it while working with an unusual archive I'd made for testing lxqt-archiver.