### PR TITLE
An option to show folder context menu with Ctrl + right click

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -837,6 +837,7 @@ FolderView::FolderView(FolderView::ViewMode _mode, QWidget *parent):
     selChangedTimer_(nullptr),
     itemDelegateMargins_(QSize(3, 3)),
     shadowHidden_(false),
+    ctrlRightClick_(false),
     smoothScrollTimer_(nullptr),
     wheelEvent_(nullptr) {
 
@@ -1215,6 +1216,10 @@ void FolderView::setShadowHidden(bool shadowHidden) {
     }
 }
 
+void FolderView::setCtrlRightClick(bool ctrlRightClick) {
+    ctrlRightClick_ = ctrlRightClick;
+}
+
 FolderView::ViewMode FolderView::viewMode() const {
     return mode;
 }
@@ -1294,7 +1299,8 @@ void FolderView::childMousePressEvent(QMouseEvent* event) {
 void FolderView::emitClickedAt(ClickType type, const QPoint& pos) {
     // indexAt() needs a point in "viewport" coordinates.
     QModelIndex index = view->indexAt(pos);
-    if(index.isValid()) {
+    if(index.isValid()
+       && (!ctrlRightClick_ || QApplication::keyboardModifiers() != Qt::ControlModifier)) {
         QVariant data = index.data(FolderModel::FileInfoRole);
         auto info = data.value<std::shared_ptr<const Fm::FileInfo>>();
         Q_EMIT clicked(type, info);

--- a/src/folderview.h
+++ b/src/folderview.h
@@ -122,6 +122,8 @@ public:
 
     void setShadowHidden(bool shadowHidden);
 
+    void setCtrlRightClick(bool ctrlRightClick);
+
     QList<int> getCustomColumnWidths() const {
         return customColumnWidths_;
     }
@@ -196,6 +198,7 @@ private:
     // the cell margins in the icon and thumbnail modes
     QSize itemDelegateMargins_;
     bool shadowHidden_;
+    bool ctrlRightClick_; // show folder context menu with Ctrl + right click
     // smooth scrolling:
     struct scollData {
         int delta;


### PR DESCRIPTION
If it's enabled (by default, it's disabled), when the user right clicks anywhere inside the view while pressing Ctrl, all items will be deselected and the folder context menu will be shown. In this way, there is no need to search for an empty space.

A pcmanfm-qt PR will follow this to make an option out of it.

NOTE: Recompile libfm-qt based apps! pcmanfm-qt is better to be recompiled with the next patch.