### PR TITLE
Select the current folder on showing the directory tree

### DIFF
--- a/src/dirtreemodel.cpp
+++ b/src/dirtreemodel.cpp
@@ -44,6 +44,7 @@ void DirTreeModel::onFileInfoJobFinished() {
     for(auto file: job->files()) {
         addRoot(std::move(file));
     }
+    Q_EMIT rootsAdded();
 }
 
 // QAbstractItemModel implementation

--- a/src/dirtreemodel.h
+++ b/src/dirtreemodel.h
@@ -78,6 +78,7 @@ public:
 
 Q_SIGNALS:
     void rowLoaded(const QModelIndex& index);
+    void rootsAdded();
 
 private Q_SLOTS:
     void onFileInfoJobFinished();

--- a/src/sidepane.cpp
+++ b/src/sidepane.cpp
@@ -139,6 +139,13 @@ void SidePane::initDirTree() {
     rootPaths.emplace_back(Fm::FilePath::fromLocalPath("/"));
     model->addRoots(std::move(rootPaths));
     static_cast<DirTreeView*>(view_)->setModel(model);
+    // wait for the roots to be added and only then set the current path
+    connect(model, &DirTreeModel::rootsAdded, view_, [this] {
+        if(mode_ == ModeDirTree) {
+            DirTreeView* dirTreeView = static_cast<DirTreeView*>(view_);
+            dirTreeView->setCurrentPath(currentPath_);
+        }
+    });
 }
 
 void SidePane::setMode(Mode mode) {
@@ -180,7 +187,6 @@ void SidePane::setMode(Mode mode) {
         view_ = dirTreeView;
         initDirTree();
         dirTreeView->setIconSize(iconSize_);
-        dirTreeView->setCurrentPath(currentPath_);
         connect(dirTreeView, &DirTreeView::chdirRequested, this, &SidePane::chdirRequested);
         connect(dirTreeView, &DirTreeView::openFolderInNewWindowRequested,
                 this, &SidePane::openFolderInNewWindowRequested);


### PR DESCRIPTION
Previously, when the directory tree was shown on the side pane, the current folder wasn't selected because the code didn't wait for the root items (`/home` and `/`) to be added.

Fixes https://github.com/lxqt/pcmanfm-qt/issues/1017

NOTE: Please recompile pcmanfm-qt after this!