### PR TITLE
Corrected path button "hidden" names

### DIFF
--- a/src/pathbar.cpp
+++ b/src/pathbar.cpp
@@ -261,9 +261,13 @@ void PathBar::setPath(Fm::FilePath path) {
             name = btnPath.toString();
         }
         else {
-            name = btnPath.baseName();
+            displayName = btnPath.baseName();
+            // "name" is used for making the path from its components in PathBar::pathForButton().
+            // So, it should be extracted from g_file_get_parse_name().
+            // (In places like trash:///, FilePath::baseName() cannot be used to make a full path.)
+            name = CStrPtr{g_path_get_basename(btnPath.displayName().get())};
         }
-        auto btn = new PathButton(name.get(), displayName ? QString::fromUtf8(displayName.get()) : QString::fromUtf8(name.get()), isRoot, buttonsWidget_);
+        auto btn = new PathButton(name.get(), QString::fromUtf8(displayName.get()), isRoot, buttonsWidget_);
         btn->show();
         connect(btn, &QAbstractButton::toggled, this, &PathBar::onButtonToggled);
         buttonsLayout_->insertWidget(0, btn);


### PR DESCRIPTION
Each path button has 2 names, one of which is shown on it and the other one is used to get the full path out of its components (between slashes). In most cases, these strings are identical but in the case of trash:/// and maybe some other places, they may be different. This patch, gets the hidden name in such a way that it can be used to remake the full path correctly.

Fixes https://github.com/lxqt/pcmanfm-qt/issues/1020