### PR TITLE
Added an option to show hidden file after others

### DIFF
--- a/src/foldermenu.cpp
+++ b/src/foldermenu.cpp
@@ -200,12 +200,18 @@ void FolderMenu::createSortMenu() {
     QAction* actionFolderFirst = new QAction(tr("Folder First"), this);
     sortMenu_->addAction(actionFolderFirst);
     actionFolderFirst->setCheckable(true);
-
     if(model->folderFirst()) {
         actionFolderFirst->setChecked(true);
     }
-
     connect(actionFolderFirst, &QAction::triggered, this, &FolderMenu::onFolderFirstActionTriggered);
+
+    QAction* actionHiddenLast = new QAction(tr("Hidden Last"), this);
+    sortMenu_->addAction(actionHiddenLast);
+    actionHiddenLast->setCheckable(true);
+    if(model->hiddenLast()) {
+        actionHiddenLast->setChecked(true);
+    }
+    connect(actionHiddenLast, &QAction::triggered, this, &FolderMenu::onHiddenLastActionTriggered);
 
     QAction* actionCaseSensitive = new QAction(tr("Case Sensitive"), this);
     sortMenu_->addAction(actionCaseSensitive);
@@ -292,6 +298,14 @@ void FolderMenu::onFolderFirstActionTriggered(bool checked) {
 
     if(model) {
         model->setFolderFirst(checked);
+    }
+}
+
+void FolderMenu::onHiddenLastActionTriggered(bool checked) {
+    ProxyFolderModel* model = view_->model();
+
+    if(model) {
+        model->setHiddenLast(checked);
     }
 }
 

--- a/src/foldermenu.h
+++ b/src/foldermenu.h
@@ -99,6 +99,7 @@ protected Q_SLOTS:
     void onShowHiddenActionTriggered(bool checked);
     void onCaseSensitiveActionTriggered(bool checked);
     void onFolderFirstActionTriggered(bool checked);
+    void onHiddenLastActionTriggered(bool checked);
     void onPropertiesActionTriggered();
     void onCustomActionTrigerred();
 

--- a/src/proxyfoldermodel.cpp
+++ b/src/proxyfoldermodel.cpp
@@ -29,6 +29,7 @@ ProxyFolderModel::ProxyFolderModel(QObject* parent):
     showHidden_(false),
     backupAsHidden_(true),
     folderFirst_(true),
+    hiddenLast_(false),
     showThumbnails_(false),
     thumbnailSize_(0) {
 
@@ -112,6 +113,14 @@ void ProxyFolderModel::setFolderFirst(bool folderFirst) {
     }
 }
 
+void ProxyFolderModel::setHiddenLast(bool hiddenLast) {
+    if(hiddenLast != hiddenLast_) {
+        hiddenLast_ = hiddenLast;
+        invalidate();
+        Q_EMIT sortFilterChanged();
+    }
+}
+
 void ProxyFolderModel::setSortCaseSensitivity(Qt::CaseSensitivity cs) {
     collator_.setCaseSensitivity(cs);
     QSortFilterProxyModel::setSortCaseSensitivity(cs);
@@ -152,6 +161,14 @@ bool ProxyFolderModel::lessThan(const QModelIndex& left, const QModelIndex& righ
             bool rightIsFolder = rightInfo->isDir();
             if(leftIsFolder != rightIsFolder) {
                 return sortOrder() == Qt::AscendingOrder ? leftIsFolder : rightIsFolder;
+            }
+        }
+
+        if(hiddenLast_) {
+            bool leftIsHidden = leftInfo->isHidden();
+            bool rightIsHidden = rightInfo->isHidden();
+            if(leftIsHidden != rightIsHidden) {
+                return sortOrder() == Qt::AscendingOrder ? rightIsHidden : leftIsHidden;
             }
         }
 

--- a/src/proxyfoldermodel.h
+++ b/src/proxyfoldermodel.h
@@ -66,6 +66,11 @@ public:
         return folderFirst_;
     }
 
+    void setHiddenLast(bool hiddenLast);
+    bool hiddenLast() {
+        return hiddenLast_;
+    }
+
     void setSortCaseSensitivity(Qt::CaseSensitivity cs);
 
     bool showThumbnails() {
@@ -107,6 +112,7 @@ private:
     bool showHidden_;
     bool backupAsHidden_;
     bool folderFirst_;
+    bool hiddenLast_;
     bool showThumbnails_;
     int thumbnailSize_;
     QList<ProxyFolderModelFilter*> filters_;


### PR DESCRIPTION
Its name is "Hidden Last". It's in the Sorting submenu of the context menu.

This patch will be followed by another one for pcmanfm-qt, so that "Hidden Last" will be completed.

NOTE: Apps that are based on libfm-qt should be recompiled.