### PR TITLE
Fixes for smooth scrolling

### DIFF
--- a/src/folderview.h
+++ b/src/folderview.h
@@ -199,14 +199,15 @@ private:
     QSize itemDelegateMargins_;
     bool shadowHidden_;
     bool ctrlRightClick_; // show folder context menu with Ctrl + right click
+
     // smooth scrolling:
-    struct scollData {
+    struct scrollData {
         int delta;
         int leftFrames;
     };
+    QList<scrollData> queuedScrollSteps_;
     QTimer *smoothScrollTimer_;
-    QWheelEvent *wheelEvent_;
-    QList<scollData> queuedScrollSteps_;
+
     QList<int> customColumnWidths_;
     QSet<int> hiddenColumns_;
 };


### PR DESCRIPTION
Smooth scrolling worked but its code had some problems, which are fixed here:

 * A typo is corrected.

 * A redundant variable (`wheelEvent_`) and a redundant condition are removed.

 * Single-row wheel scrolling (while Shift is pressed) is made smooth too.

 * An obsolete Qt method is replaced.

Closes https://github.com/lxqt/libfm-qt/issues/486

NOTE: Recompile all libfm-qt based apps after applying this patch!