### PR TITLE
Set info query cancellation error to mild in dir list job

### DIFF
--- a/src/core/dirlistjob.cpp
+++ b/src/core/dirlistjob.cpp
@@ -30,7 +30,9 @@ _retry:
         false
     };
     if(!dir_inf) {
-        ErrorAction act = emitError(err, ErrorSeverity::MODERATE);
+        ErrorAction act = emitError(err, err.domain() == G_IO_ERROR && err.code() == G_IO_ERROR_CANCELLED
+                                         ? ErrorSeverity::MILD // may happen with MTP
+                                         : ErrorSeverity::MODERATE);
         if(act == ErrorAction::RETRY) {
             err.reset();
             goto _retry;


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/1041

For some reason, that error may happen with MTP, in which case, pcmanfm-qt shouldn't show an annoying and useless error message (pcmanfm-qt only shows errors with severalties greater than `ErrorSeverity::MILD`). Moreover, if it happens in another case, the message will be useless — although I haven't encountered it without MTP.

SIDE NOTE: The current patch can be seen as the followup of an old patch, which fixed a similar issue: https://github.com/lxqt/libfm-qt/commit/670d80631b20f74eec9ffc984baf12c353398783