### PR TITLE
Added frame to side pane combo and changed its text

### DIFF
--- a/src/filedialog.ui
+++ b/src/filedialog.ui
@@ -19,7 +19,7 @@
      <item>
       <widget class="QLabel" name="lookInLabel">
        <property name="text">
-        <string>Location:</string>
+        <string>Path:</string>
        </property>
       </widget>
      </item>

--- a/src/sidepane.cpp
+++ b/src/sidepane.cpp
@@ -41,8 +41,7 @@ SidePane::SidePane(QWidget* parent):
     verticalLayout->setContentsMargins(0, 0, 0, 0);
 
     combo_ = new QComboBox(this);
-    combo_->setFrame(false);
-    combo_->addItem(tr("Places"));
+    combo_->addItem(tr("Lists")); // "Places" is already used in PlacesModel
     combo_->addItem(tr("Directory Tree"));
     connect(combo_, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &SidePane::onComboCurrentIndexChanged);
     verticalLayout->addWidget(combo_);


### PR DESCRIPTION
The combo frame is needed only with the Breeze style because other styles always draw a panel/frame for a combo.

 The combo text is changed from "Places" to "Lists" because "Places" is the title of the first list.

Also, "Location" is changed to "Path" in the file dialog.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1036