### PR TITLE
Improved bookmark DND

### DIFF
--- a/src/placesmodel.h
+++ b/src/placesmodel.h
@@ -103,6 +103,7 @@ protected:
     QStringList mimeTypes() const override;
     QMimeData* mimeData(const QModelIndexList& indexes) const override;
     bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent) override;
+    bool canDropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent) const override;
     Qt::DropActions supportedDropActions() const override;
 
     void createTrashItem();

--- a/src/placesview.cpp
+++ b/src/placesview.cpp
@@ -328,15 +328,6 @@ void PlacesView::setCurrentPath(Fm::FilePath path) {
 
 void PlacesView::dragMoveEvent(QDragMoveEvent* event) {
     QTreeView::dragMoveEvent(event);
-    /*
-    QModelIndex index = indexAt(event->pos());
-    if(event->isAccepted() && index.isValid() && index.parent() == model_->bookmarksRoot->index()) {
-      if(dropIndicatorPosition() != OnItem) {
-        event->setDropAction(Qt::LinkAction);
-        event->accept();
-      }
-    }
-    */
 }
 
 void PlacesView::dropEvent(QDropEvent* event) {


### PR DESCRIPTION
 1. For users' convenience, if a folder is dropped on the empty space below the last bookmark, it will create a new bookmark.

 2. The mouse cursor correctly shows when a drop is possible.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1046

NOTE: Recompile libfm-qt based apps after applying this patch.