### PR TITLE
Don't draw rubberband without pressing left mouse button inside view

### DIFF
--- a/src/folderview_p.h
+++ b/src/folderview_p.h
@@ -80,6 +80,7 @@ private Q_SLOTS:
 private:
   bool activationAllowed_;
   mutable bool cursorOnSelectionCorner_;
+  bool mouseLeftPressed_;
   QPoint globalItemPressPoint_; // to prevent dragging when only the view is scrolled
 };
 


### PR DESCRIPTION
Previously, a redundant rubberband (selection rectangle) might be drawn under rare circumstances. The reason was that the mouse move event might also be sent by the code of smooth wheel scrolling but the left mouse button might not be pressed inside the view at the moment of its receiving.

This patch fixes the issue by checking if the left mouse button is pressed inside the view at the receiving moment.

Fixes https://github.com/lxqt/pcmanfm-qt/issues/1055

NOTE: It's good to recompile libfm-qt based apps after this.