### PR TITLE
Fix filename renaming google drive and correct glib solution

### DIFF
--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -43,7 +43,8 @@ void FileInfo::setFromGFileInfo(const GObjectPtr<GFileInfo>& inf, const FilePath
         name_ = name;
 
     dispName_ = QString::fromUtf8(g_file_info_get_display_name(inf.get()));
-
+    editName_ = QString::fromUtf8(g_file_info_get_edit_name(inf.get()));
+  
     size_ = g_file_info_get_size(inf.get());
 
     tmp = g_file_info_get_content_type(inf.get());

--- a/src/core/fileinfo.h
+++ b/src/core/fileinfo.h
@@ -195,6 +195,10 @@ public:
     const QString& displayName() const {
         return dispName_;
     }
+    
+    const QString& editName() const {
+        return editName_;
+    }
 
     QString description() const {
         return QString::fromUtf8(mimeType_ ? mimeType_->desc() : "");
@@ -228,6 +232,7 @@ private:
     GObjectPtr<GFileInfo> inf_;
     std::string name_;
     QString dispName_;
+    QString editName_;
 
     FilePath filePath_;
     FilePath dirPath_;

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -170,9 +170,9 @@ bool changeFileName(const Fm::FilePath& filePath, const QString& newName, QWidge
 bool renameFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent) {
     FilenameDialog dlg(parent ? parent->window() : nullptr);
     dlg.setWindowTitle(QObject::tr("Rename File"));
-    dlg.setLabelText(QObject::tr("Please enter a new name:"));
-    // FIXME: what's the best way to handle non-UTF8 filename encoding here?
-    auto old_name = QString::fromStdString(file->name());
+    dlg.setLabelText(QObject::tr("Please enter a new name:"));    
+    
+    const QString& old_name = file->editName();
     dlg.setTextValue(old_name);
 
     if(file->isDir()) { // select filename extension for directories


### PR DESCRIPTION
~~Fix non-UTF8 filename renaming~~
Provides the correct glib solution
Fixes google drive file renaming (dialog showing file name)
First Part of Fix for https://github.com/lxqt/libfm-qt/issues/138

Uses g_file_get_edit_name()
If there is a problem with the commit formats feel free to make your own PR,
with any git format you like.