### PR TITLE
Handle renaming of files, whose names have invalid encodings

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -963,7 +963,11 @@ void FolderView::onClosingEditor(QWidget* editor, QAbstractItemDelegate::EndEdit
         QVariant data = index.model()->data(index, FolderModel::FileInfoRole);
         auto info = data.value<std::shared_ptr<const Fm::FileInfo>>();
         if (info) {
-            auto oldName = QString::fromStdString(info->name());
+            // NOTE: "Edit name" is used to handle invalid filename encoding.
+            auto oldName = QString::fromUtf8(g_file_info_get_edit_name(info->gFileInfo().get()));
+            if(oldName.isEmpty()) {
+                oldName = QString::fromStdString(info->name());
+            }
             if(newName == oldName) {
                 return;
             }

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -171,8 +171,11 @@ bool renameFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent) {
     FilenameDialog dlg(parent ? parent->window() : nullptr);
     dlg.setWindowTitle(QObject::tr("Rename File"));
     dlg.setLabelText(QObject::tr("Please enter a new name:"));
-    // FIXME: what's the best way to handle non-UTF8 filename encoding here?
-    auto old_name = QString::fromStdString(file->name());
+    // NOTE: "Edit name" seems the best way to handle non-UTF8 filename encoding.
+    auto old_name = QString::fromUtf8(g_file_info_get_edit_name(file->gFileInfo().get()));
+    if(old_name.isEmpty()) {
+        old_name = QString::fromStdString(file->name());
+    }
     dlg.setTextValue(old_name);
 
     if(file->isDir()) { // select filename extension for directories


### PR DESCRIPTION
The original fix was made by @damianatorrpm (see https://github.com/lxqt/libfm-qt/pull/507).

Closes https://github.com/lxqt/libfm-qt/issues/138