### PR TITLE
Use GIO's display/copy name when renaming/transferring files

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -963,7 +963,11 @@ void FolderView::onClosingEditor(QWidget* editor, QAbstractItemDelegate::EndEdit
         QVariant data = index.model()->data(index, FolderModel::FileInfoRole);
         auto info = data.value<std::shared_ptr<const Fm::FileInfo>>();
         if (info) {
-            auto oldName = QString::fromStdString(info->name());
+            // NOTE: "Edit name" is used to handle invalid filename encoding.
+            auto oldName = QString::fromUtf8(g_file_info_get_edit_name(info->gFileInfo().get()));
+            if(oldName.isEmpty()) {
+                oldName = QString::fromStdString(info->name());
+            }
             if(newName == oldName) {
                 return;
             }


### PR DESCRIPTION
Because, otherwise, renaming will not be possible in places like google-drive:/// and files in places like recent:/// or google-drive:/// will be transferred with their real names.

All credit goes to @damianatorrpm, who found the problem and its best solution.

Closes https://github.com/lxqt/libfm-qt/issues/137 and https://github.com/lxqt/libfm-qt/issues/138

NOTE: This may need more tests (by me). Please don't merge it soon if the next release comes in a few weeks.