### PR TITLE
Made template options work (in pcmanfm-qt)

### DIFF
--- a/src/core/templates.h
+++ b/src/core/templates.h
@@ -92,6 +92,7 @@ private Q_SLOTS:
 private:
     std::vector<std::shared_ptr<TemplateItem>> items_;
     std::vector<std::shared_ptr<Folder>> templateFolders_;
+    std::vector<std::shared_ptr<const MimeType>> types_;
     static std::weak_ptr<Templates> globalInstance_;
 };
 


### PR DESCRIPTION
They were "Show only user defined templates in menu" and "Show only one template for each MIME type". Templates (if any) show up when you right click inside a folder and select "Create New".

Recompilation of pcmanfm-qt shouldn't be needed but I did it and recommend it.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1070