### PR TITLE
Consider locale when sorting custom actions

### DIFF
--- a/src/customactions/fileaction.cpp
+++ b/src/customactions/fileaction.cpp
@@ -533,9 +533,10 @@ bool FileActionItem::compare_items(std::shared_ptr<const FileActionItem> a, std:
                                                                      desktop_file_name.get(), nullptr)};
                         GKeyFile* desktop_file_key = g_key_file_new();
                         if(g_key_file_load_from_file(desktop_file_key, desktop_file.get(), G_KEY_FILE_NONE, nullptr)) {
-                            auto actionName = CStrPtr{g_key_file_get_string(desktop_file_key,
-                                                                            "Desktop Entry",
-                                                                            "Name", nullptr)};
+                            auto actionName = CStrPtr{g_key_file_get_locale_string(desktop_file_key,
+                                                                                   "Desktop Entry",
+                                                                                   "Name",
+                                                                                   nullptr, nullptr)};
                             if(actionName) {
                                 itemNamesList << QString::fromUtf8(actionName.get());
                             }


### PR DESCRIPTION
It was a small issue I forgot to fix after adding support for `~/.local/share/file-manager/actions/level-zero.directory` a long time ago.