### PR TITLE
Avoid hard-coded paths

### DIFF
--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -359,11 +359,11 @@ bool FileInfo::isExecutableType() const {
         if(isNative() && (mode_ & (S_IRUSR|S_IRGRP|S_IROTH))) {
             if(isShortcut() && !target_.empty()) {
                 /* handle shortcuts from desktop to menu entries:
-                   first check for entries in /usr/share/applications and such
+                   first check for entries in ${PREFIX}/share/applications and such
                    which may be considered as a safe desktop entry path
                    then check if that is a shortcut to a native file
                    otherwise it is a link to a file under menu:// */
-                if (!g_str_has_prefix(target_.c_str(), "/usr/share/")) {
+                if (!g_str_has_prefix(target_.c_str(), "${PREFIX}/share/")) {
                     auto target = FilePath::fromPathStr(target_.c_str());
                     bool is_native = target.isNative();
                     if (is_native) {

--- a/src/core/vfs/vfs-menu.c
+++ b/src/core/vfs/vfs-menu.c
@@ -155,7 +155,7 @@ static FmXmlFileItem *_set_default_contents(FmXmlFile *file, const char *basenam
     /* set content:
         <Menu>
             <Name>Applications</Name>
-            <MergeFile type='parent'>/etc/xgd/menus/%s</MergeFile>
+            <MergeFile type='parent'>${PREFIX}/etc/xdg/menus/%s</MergeFile>
         </Menu> */
     item = fm_xml_file_item_new(menuTag_Menu);
     fm_xml_file_insert_first(file, item);
@@ -165,7 +165,7 @@ static FmXmlFileItem *_set_default_contents(FmXmlFile *file, const char *basenam
     child = fm_xml_file_item_new(menuTag_MergeFile);
     fm_xml_file_item_set_attribute(child, "type", "parent");
     /* FIXME: what is correct way to handle this? is it required at all? */
-    path = g_strdup_printf("/etc/xgd/menus/%s", basename);
+    path = g_strdup_printf("${PREFIX}/etc/xdg/menus/%s", basename);
     fm_xml_file_item_append_text(child, path, -1, FALSE);
     g_free(path);
     fm_xml_file_item_append_child(item, child);


### PR DESCRIPTION
While packaging LXQt for NetBSD I came across a few hard-coded paths.
Please review. 