### PR TITLE
Use g_list_free_full instead of casting function pointers

### DIFF
--- a/src/appchooserdialog.cpp
+++ b/src/appchooserdialog.cpp
@@ -174,8 +174,7 @@ GAppInfo* AppChooserDialog::customCommandToApp() {
                 }
                 g_free(bin2);
             }
-            g_list_foreach(apps, (GFunc)g_object_unref, nullptr);
-            g_list_free(apps);
+            g_list_free_full(apps, g_object_unref);
             if(app) {
                 goto _out;
             }

--- a/src/core/archiver.cpp
+++ b/src/core/archiver.cpp
@@ -82,8 +82,7 @@ bool Archiver::launchProgram(GAppLaunchContext* ctx, const char* cmd, const File
             uris = g_list_prepend(uris, g_strdup(file.uri().get()));
         }
         g_app_info_launch_uris(app.get(), uris, ctx, nullptr);
-        g_list_foreach(uris, (GFunc)g_free, nullptr);
-        g_list_free(uris);
+        g_list_free_full(uris, g_free);
     }
     g_free(_cmd);
     return true;

--- a/src/core/basicfilelauncher.cpp
+++ b/src/core/basicfilelauncher.cpp
@@ -177,8 +177,7 @@ bool BasicFileLauncher::launchWithApp(GAppInfo* app, const FilePathList& paths, 
     uris = g_list_reverse(uris);
     GErrorPtr err;
     bool ret = bool(g_app_info_launch_uris(app, uris, ctx, &err));
-    g_list_foreach(uris, reinterpret_cast<GFunc>(g_free), nullptr);
-    g_list_free(uris);
+    g_list_free_full(uris, g_free);
     if(!ret) {
         // FIXME: show error for all files
         showError(ctx, err, paths.empty() ? FilePath{} : paths[0]);
@@ -269,8 +268,7 @@ bool BasicFileLauncher::launchDesktopEntry(const char *desktopEntryName, const F
         uris = g_list_reverse(uris);
         GErrorPtr err;
         ret = bool(fm_app_info_launch(app, uris, ctx, &err));
-        g_list_foreach(uris, reinterpret_cast<GFunc>(g_free), nullptr);
-        g_list_free(uris);
+        g_list_free_full(uris, g_free);
         if(!ret) {
             // FIXME: show error for all files
             showError(ctx, err, paths.empty() ? FilePath{} : paths[0]);

--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -323,8 +323,7 @@ void FileMenu::openFilesWithApp(GAppInfo* app) {
     }
     uris = g_list_reverse(uris); // respect the original order
     fm_app_info_launch_uris(app, uris, nullptr, nullptr);
-    g_list_foreach(uris, (GFunc)g_free, nullptr);
-    g_list_free(uris);
+    g_list_free_full(uris, g_free);
 }
 
 void FileMenu::onApplicationTriggered() {


### PR DESCRIPTION
This is more straightforward and avoids both compiler warnings (with Clang) and the problems that could result if the code is compiled for a platform with an unusual calling convention.