### PR TITLE
Changed "logout" to "session" in password dialog

### DIFF
--- a/src/mount-operation-password.ui
+++ b/src/mount-operation-password.ui
@@ -134,7 +134,7 @@
    <item>
     <widget class="QRadioButton" name="sessionPassword">
      <property name="text">
-      <string>Remember password until you &amp;logout</string>
+      <string>Remember password for &amp;this session</string>
      </property>
      <attribute name="buttonGroup">
       <string notr="true">passwordGroup</string>


### PR DESCRIPTION
Because a keyring session may not be the same as a desktop session, especially when a password is saved under the `login` keyring.