### PR TITLE
Update text color of places view if style changes in runtime

### DIFF
--- a/src/sidepane.cpp
+++ b/src/sidepane.cpp
@@ -19,6 +19,7 @@
 
 
 #include "sidepane.h"
+#include <QEvent>
 #include <QComboBox>
 #include <QVBoxLayout>
 #include <QHeaderView>
@@ -49,6 +50,19 @@ SidePane::SidePane(QWidget* parent):
 
 SidePane::~SidePane() {
     // qDebug("delete SidePane");
+}
+
+bool SidePane::event(QEvent* event) {
+    // when the SidePane's style changes, we should set the text color of
+    // PlacesView to its window text color again because the latter may have changed
+    if(event->type() == QEvent::StyleChange && mode_ == ModePlaces) {
+        if(PlacesView* placesView = static_cast<PlacesView*>(view_)) {
+            QPalette p = placesView->palette();
+            p.setColor(QPalette::Text, p.color(QPalette::WindowText));
+            placesView->setPalette(p);
+        }
+    }
+    return QWidget::event(event);
 }
 
 void SidePane::onComboCurrentIndexChanged(int current) {

--- a/src/sidepane.h
+++ b/src/sidepane.h
@@ -111,6 +111,9 @@ Q_SIGNALS:
 
     void hiddenPlaceSet(const QString& str, bool hide);
 
+protected:
+    bool event(QEvent* event) override;
+
 protected Q_SLOTS:
     void onComboCurrentIndexChanged(int current);
 


### PR DESCRIPTION
Otherwise, if the style is switched between dark and light in runtime (which will soon be possible in LXQt), the text color will not change and might not have enough contrast with its background.