### PR TITLE
File dialog: Remember sorting and showing of hidden files

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -191,6 +191,78 @@ void FileDialog::setSplitterPos(int pos) {
     ui->splitter->setSizes(sizes);
 }
 
+int FileDialog::sortColumn() const {
+    if(proxyModel_) {
+        return proxyModel_->sortColumn();
+    }
+    return 0;
+}
+
+Qt::SortOrder FileDialog::sortOrder() const {
+    if(proxyModel_) {
+        return proxyModel_->sortOrder();
+    }
+    return Qt::AscendingOrder;
+}
+
+void FileDialog::sort(int col, Qt::SortOrder order) {
+    if(proxyModel_) {
+        proxyModel_->sort(col, order);
+    }
+}
+
+bool FileDialog::sortFolderFirst() const {
+    if(proxyModel_) {
+        return proxyModel_->folderFirst();
+    }
+    return true;
+}
+
+void FileDialog::setSortFolderFirst(bool value) {
+    if(proxyModel_) {
+        proxyModel_->setFolderFirst(value);
+    }
+}
+
+bool FileDialog::sortHiddenLast() const {
+    if(proxyModel_) {
+        return proxyModel_->hiddenLast();
+    }
+    return false;
+}
+
+void FileDialog::setSortHiddenLast(bool value) {
+    if(proxyModel_) {
+        proxyModel_->setHiddenLast(value);
+    }
+}
+
+bool FileDialog::sortCaseSensitive() const {
+    if(proxyModel_) {
+        return proxyModel_->sortCaseSensitivity() == Qt::CaseSensitive ? true : false;
+    }
+    return false;
+}
+
+void FileDialog::setSortCaseSensitive(bool value) {
+    if(proxyModel_) {
+        proxyModel_->setSortCaseSensitivity(value ? Qt::CaseSensitive : Qt::CaseInsensitive);
+    }
+}
+
+bool FileDialog::showHidden() const {
+    if(proxyModel_) {
+        return proxyModel_->showHidden();
+    }
+    return false;
+}
+
+void FileDialog::setShowHidden(bool showHidden) {
+    if(proxyModel_) {
+        proxyModel_->setShowHidden(showHidden);
+    }
+}
+
 // This should always be used instead of getting text directly from the entry.
 QStringList FileDialog::parseNames() const {
     // parse the file names from the text entry

--- a/src/filedialog.h
+++ b/src/filedialog.h
@@ -126,6 +126,22 @@ public:
     int splitterPos() const;
     void setSplitterPos(int pos);
 
+    int sortColumn() const;
+    Qt::SortOrder sortOrder() const;
+    void sort(int col, Qt::SortOrder order = Qt::AscendingOrder);
+
+    bool sortFolderFirst() const;
+    void setSortFolderFirst(bool value);
+
+    bool sortHiddenLast() const;
+    void setSortHiddenLast(bool value);
+
+    bool sortCaseSensitive() const;
+    void setSortCaseSensitive(bool value);
+
+    bool showHidden() const;
+    void setShowHidden(bool showHidden);
+
 private Q_SLOTS:
     void onCurrentRowChanged(const QModelIndex &current, const QModelIndex& /*previous*/);
     void onSelectionChanged(const QItemSelection& /*selected*/, const QItemSelection& /*deselected*/);

--- a/src/filedialoghelper.cpp
+++ b/src/filedialoghelper.cpp
@@ -16,6 +16,12 @@ namespace Fm {
 inline static const QString viewModeToString(Fm::FolderView::ViewMode value);
 inline static Fm::FolderView::ViewMode viewModeFromString(const QString& str);
 
+inline static const QString sortColumnToString(FolderModel::ColumnId value);
+inline static FolderModel::ColumnId sortColumnFromString(const QString str);
+
+inline static const QString sortOrderToString(Qt::SortOrder order);
+inline static Qt::SortOrder sortOrderFromString(const QString str);
+
 FileDialogHelper::FileDialogHelper() {
     // can only be used after libfm-qt initialization
     dlg_ = std::unique_ptr<Fm::FileDialog>(new Fm::FileDialog());
@@ -228,6 +234,72 @@ Fm::FolderView::ViewMode viewModeFromString(const QString& str) {
     return ret;
 }
 
+static Fm::FolderModel::ColumnId sortColumnFromString(const QString str) {
+    Fm::FolderModel::ColumnId ret;
+    if(str == QLatin1String("name")) {
+        ret = Fm::FolderModel::ColumnFileName;
+    }
+    else if(str == QLatin1String("type")) {
+        ret = Fm::FolderModel::ColumnFileType;
+    }
+    else if(str == QLatin1String("size")) {
+        ret = Fm::FolderModel::ColumnFileSize;
+    }
+    else if(str == QLatin1String("mtime")) {
+        ret = Fm::FolderModel::ColumnFileMTime;
+    }
+    else if(str == QLatin1String("dtime")) {
+        ret = Fm::FolderModel::ColumnFileDTime;
+    }
+    else if(str == QLatin1String("owner")) {
+        ret = Fm::FolderModel::ColumnFileOwner;
+    }
+    else if(str == QLatin1String("group")) {
+        ret = Fm::FolderModel::ColumnFileGroup;
+    }
+    else {
+        ret = Fm::FolderModel::ColumnFileName;
+    }
+    return ret;
+}
+
+static const QString sortColumnToString(Fm::FolderModel::ColumnId value) {
+    QString ret;
+    switch(value) {
+    case Fm::FolderModel::ColumnFileName:
+    default:
+        ret = QLatin1String("name");
+        break;
+    case Fm::FolderModel::ColumnFileType:
+        ret = QLatin1String("type");
+        break;
+    case Fm::FolderModel::ColumnFileSize:
+        ret = QLatin1String("size");
+        break;
+    case Fm::FolderModel::ColumnFileMTime:
+        ret = QLatin1String("mtime");
+        break;
+    case Fm::FolderModel::ColumnFileDTime:
+        ret = QLatin1String("dtime");
+        break;
+    case Fm::FolderModel::ColumnFileOwner:
+        ret = QLatin1String("owner");
+        break;
+    case Fm::FolderModel::ColumnFileGroup:
+        ret = QLatin1String("group");
+        break;
+    }
+    return ret;
+}
+
+static const QString sortOrderToString(Qt::SortOrder order) {
+    return (order == Qt::DescendingOrder ? QLatin1String("descending") : QLatin1String("ascending"));
+}
+
+static Qt::SortOrder sortOrderFromString(const QString str) {
+    return (str == QLatin1String("descending") ? Qt::DescendingOrder : Qt::AscendingOrder);
+}
+
 void FileDialogHelper::loadSettings() {
     QSettings settings(QSettings::UserScope, QStringLiteral("lxqt"), QStringLiteral("filedialog"));
     settings.beginGroup (QStringLiteral("Sizes"));
@@ -237,6 +309,11 @@ void FileDialogHelper::loadSettings() {
 
    settings.beginGroup (QStringLiteral("View"));
    dlg_->setViewMode(viewModeFromString(settings.value(QStringLiteral("Mode"), QStringLiteral("Detailed")).toString()));
+   dlg_->sort(sortColumnFromString(settings.value(QStringLiteral("SortColumn")).toString()), sortOrderFromString(settings.value(QStringLiteral("SortOrder")).toString()));
+   dlg_->setSortFolderFirst(settings.value(QStringLiteral("SortFolderFirst"), true).toBool());
+   dlg_->setSortHiddenLast(settings.value(QStringLiteral("SortHiddenLast"), false).toBool());
+   dlg_->setSortCaseSensitive(settings.value(QStringLiteral("SortCaseSensitive"), false).toBool());
+   dlg_->setShowHidden(settings.value(QStringLiteral("ShowHidden"), false).toBool());
    settings.endGroup();
 }
 
@@ -257,6 +334,30 @@ void FileDialogHelper::saveSettings() {
     QString mode = viewModeToString(dlg_->viewMode());
     if(settings.value(QStringLiteral("Mode")) != mode) {
         settings.setValue(QStringLiteral("Mode"), mode);
+    }
+    QString sortColumn = sortColumnToString(static_cast<Fm::FolderModel::ColumnId>(dlg_->sortColumn()));
+    if(settings.value(QStringLiteral("SortColumn")) != sortColumn) {
+        settings.setValue(QStringLiteral("SortColumn"), sortColumn);
+    }
+    QString sortOrder = sortOrderToString(dlg_->sortOrder());
+    if(settings.value(QStringLiteral("SortOrder")) != sortOrder) {
+        settings.setValue(QStringLiteral("SortOrder"), sortOrder);
+    }
+    bool sortFolderFirst = dlg_->sortFolderFirst();
+    if(settings.value(QStringLiteral("SortFolderFirst")).toBool() != sortFolderFirst) {
+        settings.setValue(QStringLiteral("SortFolderFirst"), sortFolderFirst);
+    }
+    bool sortHiddenLast = dlg_->sortHiddenLast();
+    if(settings.value(QStringLiteral("SortHiddenLast")).toBool() != sortHiddenLast) {
+        settings.setValue(QStringLiteral("SortHiddenLast"), sortHiddenLast);
+    }
+    bool sortCaseSensitive = dlg_->sortCaseSensitive();
+    if(settings.value(QStringLiteral("SortCaseSensitive")).toBool() != sortCaseSensitive) {
+        settings.setValue(QStringLiteral("SortCaseSensitive"), sortCaseSensitive);
+    }
+    bool showHidden = dlg_->showHidden();
+    if(settings.value(QStringLiteral("ShowHidden")).toBool() != showHidden) {
+        settings.setValue(QStringLiteral("ShowHidden"), showHidden);
     }
     settings.endGroup();
 }


### PR DESCRIPTION
WARNING: pcmanfm-qt and lxqt-archiver should be recompiled because they use the file dialog directly (pcmanfm-qt in its wallpaper browser and lxqt-archiver everywhere).

NOTE: This is for LXQt's native file dialog when called by any Qt app, not for hard-coded file dialogs like those of pcmanfm-qt's wallpaper browser or lxqt-archiver's dialogs (which should manage their settings independently if needed).