### PR TITLE
File dialog: Remember hidden places in side-pane

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -44,6 +44,7 @@ FileDialog::FileDialog(QWidget* parent, FilePath path) :
     connect(ui->sidePane, &SidePane::chdirRequested, [this](int /*type*/, const FilePath &path) {
         setDirectoryPath(path);
     });
+    connect(ui->sidePane, &SidePane::hiddenPlaceSet, this, &FileDialog::onSettingHiddenPlace);
 
     // folder view
     proxyModel_ = new ProxyFolderModel(this);
@@ -260,6 +261,21 @@ bool FileDialog::showHidden() const {
 void FileDialog::setShowHidden(bool showHidden) {
     if(proxyModel_) {
         proxyModel_->setShowHidden(showHidden);
+    }
+}
+
+void FileDialog::setHiddenPlaces(const QSet<QString>& items) {
+    ui->sidePane->restoreHiddenPlaces(items);
+    hiddenPlaces_.clear();
+    hiddenPlaces_ = items;
+}
+
+void FileDialog::onSettingHiddenPlace(const QString& str, bool hide) {
+    if(hide) {
+        hiddenPlaces_ << str;
+    }
+    else {
+        hiddenPlaces_.remove(str);
     }
 }
 

--- a/src/filedialog.h
+++ b/src/filedialog.h
@@ -142,6 +142,11 @@ public:
     bool showHidden() const;
     void setShowHidden(bool showHidden);
 
+    QSet<QString> getHiddenPlaces() const {
+        return hiddenPlaces_;
+    }
+    void setHiddenPlaces(const QSet<QString>& items);
+
 private Q_SLOTS:
     void onCurrentRowChanged(const QModelIndex &current, const QModelIndex& /*previous*/);
     void onSelectionChanged(const QItemSelection& /*selected*/, const QItemSelection& /*deselected*/);
@@ -149,6 +154,7 @@ private Q_SLOTS:
     void onNewFolder();
     void onViewModeToggled(bool active);
     void goHome();
+    void onSettingHiddenPlace(const QString& str, bool hide);
 
 Q_SIGNALS:
     // emitted when the dialog is accepted and some files are selected
@@ -231,6 +237,7 @@ private:
     QString explicitLabels_[5];
     // needed for disconnecting Fm::Folder signal from lambda:
     QMetaObject::Connection lambdaConnection_;
+    QSet<QString> hiddenPlaces_;
 };
 
 

--- a/src/filedialoghelper.cpp
+++ b/src/filedialoghelper.cpp
@@ -315,8 +315,13 @@ void FileDialogHelper::loadSettings() {
    dlg_->setSortCaseSensitive(settings.value(QStringLiteral("SortCaseSensitive"), false).toBool());
    dlg_->setShowHidden(settings.value(QStringLiteral("ShowHidden"), false).toBool());
    settings.endGroup();
+
+   settings.beginGroup(QStringLiteral("Places"));
+   dlg_->setHiddenPlaces(settings.value(QStringLiteral("HiddenPlaces")).toStringList().toSet());
+   settings.endGroup();
 }
 
+// This also prevents redundant writings whenever a file dialog is closed without a change in its settings.
 void FileDialogHelper::saveSettings() {
     QSettings settings(QSettings::UserScope, QStringLiteral("lxqt"), QStringLiteral("filedialog"));
     settings.beginGroup (QStringLiteral("Sizes"));
@@ -358,6 +363,17 @@ void FileDialogHelper::saveSettings() {
     bool showHidden = dlg_->showHidden();
     if(settings.value(QStringLiteral("ShowHidden")).toBool() != showHidden) {
         settings.setValue(QStringLiteral("ShowHidden"), showHidden);
+    }
+    settings.endGroup();
+
+    settings.beginGroup(QStringLiteral("Places"));
+    QSet<QString> hiddenPlaces = dlg_->getHiddenPlaces();
+    if(hiddenPlaces.isEmpty()) { // don't save "@Invalid()"
+        settings.remove(QStringLiteral("HiddenPlaces"));
+    }
+    else if(hiddenPlaces != settings.value(QStringLiteral("HiddenPlaces")).toStringList().toSet()) {
+        QStringList sl = hiddenPlaces.toList();
+        settings.setValue(QStringLiteral("HiddenPlaces"), sl);
     }
     settings.endGroup();
 }


### PR DESCRIPTION
WARNING: pcmanfm-qt and lxqt-archiver should be recompiled because they use the file dialog directly (pcmanfm-qt in its wallpaper browser and lxqt-archiver everywhere).