### PR TITLE
Fixed setting of default app in Properties dialog

### DIFF
--- a/src/appchooserdialog.cpp
+++ b/src/appchooserdialog.cpp
@@ -20,6 +20,7 @@
 
 #include "appchooserdialog.h"
 #include "ui_app-chooser-dialog.h"
+#include "utilities.h"
 #include <QPushButton>
 #include <gio/gdesktopappinfo.h>
 #include <glib/gstdio.h>
@@ -245,7 +246,7 @@ void AppChooserDialog::accept() {
 #endif
             /* if need to set default */
             if(ui->setDefault->isChecked()) {
-                g_app_info_set_as_default_for_type(selectedApp_.get(), mimeType_->name(), nullptr);
+                setDefaultAppForType(selectedApp_, mimeType_);
             }
         }
     }

--- a/src/filepropsdialog.cpp
+++ b/src/filepropsdialog.cpp
@@ -439,7 +439,7 @@ void FilePropsDialog::accept() {
     // applications
     if(mimeType && ui->openWith->isChanged()) {
         auto currentApp = ui->openWith->selectedApp();
-        g_app_info_set_as_default_for_type(currentApp.get(), mimeType->name(), nullptr);
+        setDefaultAppForType(currentApp, mimeType);
     }
 
     // check if chown or chmod is needed

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -55,6 +55,8 @@ LIBFM_QT_API bool changeFileName(const Fm::FilePath& path, const QString& newNam
 
 LIBFM_QT_API bool renameFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent = nullptr);
 
+LIBFM_QT_API void setDefaultAppForType(const Fm::GAppInfoPtr app, std::shared_ptr<const Fm::MimeType> mimeType);
+
 enum CreateFileType {
     CreateNewFolder,
     CreateNewTextFile,


### PR DESCRIPTION
GLib has a weird problem. On the one hand, `g_app_info_set_as_default_for_type()` writes to `~/.config/mimeapps.list`. On the other hand, the DE-specific list — e.g., `~/.config/lxqt-mimeapps.list` in LXQt — has priority over it and GLib respects that. Therefore, if the latter exists and contains some default apps, `g_app_info_set_as_default_for_type()` could not change them.

This patch solves the problem by adding a utility function that sets the default app directly inside the DE-specific list.

Also, see https://github.com/lxqt/libqtxdg/pull/219.