### PR TITLE
Better focus change with Tab/BackTab in file dialog

### DIFF
--- a/src/filedialog.h
+++ b/src/filedialog.h
@@ -147,6 +147,9 @@ public:
     }
     void setHiddenPlaces(const QSet<QString>& items);
 
+protected:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
 private Q_SLOTS:
     void onCurrentRowChanged(const QModelIndex &current, const QModelIndex& /*previous*/);
     void onSelectionChanged(const QItemSelection& /*selected*/, const QItemSelection& /*deselected*/);


### PR DESCRIPTION
With this patch, Tab key switches the focus from the main view to the name entry and BackTab does the reverse.

A filter event is used because `QWidget::setTabOrder()` cannot set the desired tab order in the file dialog (probably, due to an old Qt bug).

Closes https://github.com/lxqt/libfm-qt/issues/557

NOTE: Recompile pcmanfm-qt and lxqt-archiver after this.