### PR TITLE
Cleaned up the code for graying out cut files

### DIFF
--- a/src/core/folder.h
+++ b/src/core/folder.h
@@ -85,8 +85,8 @@ public:
     const std::shared_ptr<const FileInfo> &info() const;
 
     void setCutFiles(const std::shared_ptr<const HashSet>& cutFilesHashSet);
-    bool hasCutFiles() const;
-    bool hadCutFiles();
+    bool hasCutFile() const;
+    void setNoCutFile();
 
     void updateCutFiles();
 
@@ -192,9 +192,9 @@ private:
     bool has_fs_info : 1;
     bool defer_content_test : 1;
 
+    bool hasCutFile_;
+
     static std::unordered_map<FilePath, std::weak_ptr<Folder>, FilePathHash> cache_;
-    static QString cutFilesDirPath_;
-    static QString lastCutFilesDirPath_;
     static std::shared_ptr<const HashSet> cutFilesHashSet_;
     static std::mutex mutex_;
 };

--- a/src/core/iconinfo.cpp
+++ b/src/core/iconinfo.cpp
@@ -66,28 +66,16 @@ void IconInfo::updateQIcons() {
     }
 }
 
-QIcon IconInfo::qicon(const bool& transparent) const {
-    if(Q_LIKELY(!transparent)) {
-        if(Q_UNLIKELY(qicon_.isNull() && gicon_)) {
-            if(!G_IS_FILE_ICON(gicon_.get())) {
-                qicon_ = QIcon(new IconEngine{shared_from_this()});
-            }
-            else {
-                qicon_ = getFirst(internalQicons_);
-            }
+QIcon IconInfo::qicon() const {
+    if(Q_UNLIKELY(qicon_.isNull() && gicon_)) {
+        if(!G_IS_FILE_ICON(gicon_.get())) {
+            qicon_ = QIcon(new IconEngine{shared_from_this()});
+        }
+        else {
+            qicon_ = getFirst(internalQicons_);
         }
     }
-    else { // transparent == true
-        if(Q_UNLIKELY(qiconTransparent_.isNull() && gicon_)) {
-            if(!G_IS_FILE_ICON(gicon_.get())) {
-                qiconTransparent_ = QIcon(new IconEngine{shared_from_this(), transparent});
-            }
-            else {
-                qiconTransparent_ = getFirst(internalQicons_);
-            }
-        }
-    }
-    return !transparent ? qicon_ : qiconTransparent_;
+    return qicon_;
 }
 
 QList<QIcon> IconInfo::qiconsFromNames(const char* const* names) {

--- a/src/core/iconinfo.h
+++ b/src/core/iconinfo.h
@@ -63,7 +63,7 @@ public:
         return gicon_;
     }
 
-    QIcon qicon(const bool& transparent = false) const;
+    QIcon qicon() const;
 
     bool hasEmblems() const {
         return G_IS_EMBLEMED_ICON(gicon_.get());
@@ -97,7 +97,6 @@ private:
 private:
     GIconPtr gicon_;
     mutable QIcon qicon_;
-    mutable QIcon qiconTransparent_;
     mutable QList<QIcon> internalQicons_;
 
     static std::unordered_map<GIcon*, std::shared_ptr<IconInfo>, GIconHash, GIconEqual> cache_;

--- a/src/core/iconinfo_p.h
+++ b/src/core/iconinfo_p.h
@@ -31,7 +31,7 @@ namespace Fm {
 class IconEngine: public QIconEngine {
 public:
 
-    IconEngine(std::shared_ptr<const Fm::IconInfo> info, const bool& transparent = false);
+    IconEngine(std::shared_ptr<const Fm::IconInfo> info);
 
     ~IconEngine() override;
 
@@ -55,11 +55,9 @@ public:
 
 private:
     std::weak_ptr<const Fm::IconInfo> info_;
-    bool transparent_;
 };
 
-IconEngine::IconEngine(std::shared_ptr<const IconInfo> info, const bool& transparent):
-    info_{info}, transparent_{transparent} {
+IconEngine::IconEngine(std::shared_ptr<const IconInfo> info): info_{info} {
 }
 
 IconEngine::~IconEngine() {
@@ -82,14 +80,7 @@ QString IconEngine::key() const {
 void IconEngine::paint(QPainter* painter, const QRect& rect, QIcon::Mode mode, QIcon::State state) {
     auto info = info_.lock();
     if(info) {
-        if(transparent_) {
-            painter->save();
-            painter->setOpacity(0.45);
-        }
         info->internalQicon().paint(painter, rect, Qt::AlignCenter, mode, state);
-        if(transparent_) {
-            painter->restore();
-        }
     }
 }
 

--- a/src/foldermodelitem.cpp
+++ b/src/foldermodelitem.cpp
@@ -77,59 +77,20 @@ const QString& FolderModelItem::displaySize() const {
     return dispSize_;
 }
 
-bool FolderModelItem::isCut() const {
-    return info->isCut();
-}
-
 // find thumbnail of the specified size
 // The returned thumbnail item is temporary and short-lived
 // If you need to use the struct later, copy it to your own struct to keep it.
-FolderModelItem::Thumbnail* FolderModelItem::findThumbnail(int size, bool transparent) {
+FolderModelItem::Thumbnail* FolderModelItem::findThumbnail(int size) {
     QVector<Thumbnail>::iterator it;
-    Thumbnail* transThumb = nullptr;
     for(it = thumbnails.begin(); it != thumbnails.end(); ++it) {
-        if(it->size == size) {
-            if(it->status != ThumbnailLoaded) {
-                return it;
-            }
-            else { // it->status == ThumbnailLoaded
-                if(it->transparent == false && transparent == true
-                        && size < 48 /* (dirty) needed only for 'compact' and 'details list' view */ ) {
-                    transThumb = it; // save thumb to add transparency later
-                }
-                else {
-                    return it; // an image of the same size and transparency is found
-                }
-            }
+        if(it->size == size) { // an image of the same size is found
+            return it;
         }
     }
-    if(transThumb) {
-        QImage image(transThumb->image);
-
-        if(!image.hasAlphaChannel()) {
-            image = image.convertToFormat(QImage::Format_ARGB32);
-        }
-
-        // add transparency to image
-        QPainter p;
-        p.begin(&image);
-        p.setCompositionMode(QPainter::CompositionMode_DestinationIn);
-        p.fillRect(image.rect(), QColor(0, 0, 0, 115 /* alpha 45% */));
-        p.end();
-
-        // add image to thumbnails
-        Thumbnail thumbnail;
-        thumbnail.status = ThumbnailLoaded;
-        thumbnail.image = image;
-        thumbnail.size = size;
-        thumbnail.transparent = true;
-        thumbnails.append(thumbnail);
-    }
-    else if(it == thumbnails.end()) {
+    if(it == thumbnails.end()) {
         Thumbnail thumbnail;
         thumbnail.status = ThumbnailNotChecked;
         thumbnail.size = size;
-        thumbnail.transparent = false;
         thumbnails.append(thumbnail);
     }
     return &thumbnails.back();

--- a/src/foldermodelitem.h
+++ b/src/foldermodelitem.h
@@ -43,7 +43,6 @@ public:
 
     struct Thumbnail {
         int size;
-        bool transparent;
         ThumbnailStatus status;
         QImage image;
     };
@@ -61,9 +60,9 @@ public:
         return info->name();
     }
 
-    QIcon icon(bool transparent = false) const {
+    QIcon icon() const {
         const auto i = info->icon();
-        return i ? i->qicon(transparent) : QIcon{};
+        return i ? i->qicon() : QIcon{};
     }
 
     QString ownerName() const;
@@ -76,9 +75,7 @@ public:
 
     const QString &displaySize() const;
 
-    bool isCut() const;
-
-    Thumbnail* findThumbnail(int size, bool transparent);
+    Thumbnail* findThumbnail(int size);
 
     void removeThumbnail(int size);
 


### PR DESCRIPTION
Several redundant variables/methods were left from the first implementation. Their removal enhances code readability because their logic was absurdly complex and some of them did nothing.

There is no practical change in functionality though: cut files are grayed out inside a single folder — no multi-folder support yet but this cleanup may pave the way for its implementation.

WARNING: pcmanfm-qt and other libfm-qt based apps should be recompiled after this.

Closes https://github.com/lxqt/libfm-qt/issues/563