### PR TITLE
Better code for graying out cut files

### DIFF
--- a/src/core/dirlistjob.cpp
+++ b/src/core/dirlistjob.cpp
@@ -6,8 +6,8 @@
 
 namespace Fm {
 
-DirListJob::DirListJob(const FilePath& path, Flags _flags, const std::shared_ptr<const HashSet>& cutFilesHashSet):
-    dir_path{path}, flags{_flags}, cutFilesHashSet_{cutFilesHashSet} {
+DirListJob::DirListJob(const FilePath& path, Flags _flags):
+    dir_path{path}, flags{_flags} {
 }
 
 void DirListJob::exec() {
@@ -104,11 +104,6 @@ _retry:
                 auto fileInfo = std::make_shared<FileInfo>(inf, FilePath(), realParentPath);
                 if(emit_files_found) {
                     // Q_EMIT filesFound();
-                }
-
-                if(cutFilesHashSet_
-                        && cutFilesHashSet_->count(fileInfo->path().hash()) > 0) {
-                    fileInfo->bindCutFiles(cutFilesHashSet_);
                 }
 
                 foundFiles.push_back(std::move(fileInfo));

--- a/src/core/dirlistjob.h
+++ b/src/core/dirlistjob.h
@@ -19,7 +19,7 @@ public:
         DETAILED = 1 << 1
     };
 
-    explicit DirListJob(const FilePath& path, Flags flags, const std::shared_ptr<const HashSet>& cutFilesHashSet = nullptr);
+    explicit DirListJob(const FilePath& path, Flags flags);
 
     FileInfoList& files() {
         return files_;
@@ -54,7 +54,6 @@ private:
     Flags flags;
     std::shared_ptr<const FileInfo> dir_fi;
     FileInfoList files_;
-    const std::shared_ptr<const HashSet> cutFilesHashSet_;
     bool emit_files_found;
     // guint delay_add_files_handler;
     // GSList* files_to_add;

--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -336,10 +336,6 @@ _file_is_symlink:
 #endif
 }
 
-void FileInfo::bindCutFiles(const std::shared_ptr<const HashSet>& cutFilesHashSet) {
-    cutFilesHashSet_ = cutFilesHashSet;
-}
-
 bool FileInfo::canThumbnail() const {
     /* We cannot use S_ISREG here as this exclude all symlinks */
     if(size_ == 0 ||  /* don't generate thumbnails for empty files */

--- a/src/core/fileinfo.h
+++ b/src/core/fileinfo.h
@@ -172,10 +172,6 @@ public:
         return dirPath_ ? dirPath_.isNative() : path().isNative();
     }
 
-    bool isCut() const {
-        return !cutFilesHashSet_.expired();
-    }
-
     mode_t mode() const {
         return mode_;
     }
@@ -209,8 +205,6 @@ public:
     }
 
     void setFromGFileInfo(const GFileInfoPtr& inf, const FilePath& filePath, const FilePath& parentDirPath);
-
-    void bindCutFiles(const std::shared_ptr<const HashSet>& cutFilesHashSet);
 
     const std::forward_list<std::shared_ptr<const IconInfo>>& emblems() const {
         return emblems_;
@@ -262,9 +256,6 @@ private:
     bool isIconChangeable_ : 1; /* TRUE if icon can be changed */
     bool isHiddenChangeable_ : 1; /* TRUE if hidden can be changed */
     bool isReadOnly_ : 1; /* TRUE if host FS is R/O */
-
-    std::weak_ptr<const HashSet> cutFilesHashSet_;
-    // std::vector<std::tuple<int, void*, void(void*)>> extraData_;
 };
 
 

--- a/src/core/fileinfojob.cpp
+++ b/src/core/fileinfojob.cpp
@@ -3,10 +3,9 @@
 
 namespace Fm {
 
-FileInfoJob::FileInfoJob(FilePathList paths, const std::shared_ptr<const HashSet>& cutFilesHashSet):
+FileInfoJob::FileInfoJob(FilePathList paths):
     Job(),
-    paths_{std::move(paths)},
-    cutFilesHashSet_{cutFilesHashSet} {
+    paths_{std::move(paths)} {
 }
 
 void FileInfoJob::exec() {
@@ -27,13 +26,6 @@ void FileInfoJob::exec() {
             };
             if(inf) {
                 auto fileInfoPtr = std::make_shared<FileInfo>(inf, path);
-
-                // FIXME: this is not elegant
-                if(cutFilesHashSet_
-                        && cutFilesHashSet_->count(path.hash())) {
-                    fileInfoPtr->bindCutFiles(cutFilesHashSet_);
-                }
-
                 results_.push_back(fileInfoPtr);
                 Q_EMIT gotInfo(path, results_.back());
             }

--- a/src/core/fileinfojob.h
+++ b/src/core/fileinfojob.h
@@ -13,7 +13,7 @@ class LIBFM_QT_API FileInfoJob : public Job {
     Q_OBJECT
 public:
 
-    explicit FileInfoJob(FilePathList paths, const std::shared_ptr<const HashSet>& cutFilesHashSet = nullptr);
+    explicit FileInfoJob(FilePathList paths);
 
     const FilePathList& paths() const {
         return paths_;
@@ -36,7 +36,6 @@ protected:
 private:
     FilePathList paths_;
     FileInfoList results_;
-    const std::shared_ptr<const HashSet> cutFilesHashSet_;
     FilePath currentPath_;
 };
 

--- a/src/core/folder.h
+++ b/src/core/folder.h
@@ -84,12 +84,6 @@ public:
 
     const std::shared_ptr<const FileInfo> &info() const;
 
-    void setCutFiles(const std::shared_ptr<const HashSet>& cutFilesHashSet);
-    bool hasCutFiles() const;
-    bool hadCutFiles();
-
-    void updateCutFiles();
-
     void forEachFile(std::function<void (const std::shared_ptr<const FileInfo>&)> func) const {
         std::lock_guard<std::mutex> lock{mutex_};
         for(auto it = files_.begin(); it != files_.end(); ++it) {
@@ -105,8 +99,6 @@ Q_SIGNALS:
     void filesAdded(FileInfoList& addedFiles);
 
     void filesChanged(std::vector<FileInfoPair>& changePairs);
-
-    void cutFilesChanged(std::vector<FileInfoPair>& changePairs);
 
     void filesRemoved(FileInfoList& removedFiles);
 
@@ -193,9 +185,6 @@ private:
     bool defer_content_test : 1;
 
     static std::unordered_map<FilePath, std::weak_ptr<Folder>, FilePathHash> cache_;
-    static QString cutFilesDirPath_;
-    static QString lastCutFilesDirPath_;
-    static std::shared_ptr<const HashSet> cutFilesHashSet_;
     static std::mutex mutex_;
 };
 

--- a/src/core/iconinfo.cpp
+++ b/src/core/iconinfo.cpp
@@ -66,28 +66,16 @@ void IconInfo::updateQIcons() {
     }
 }
 
-QIcon IconInfo::qicon(const bool& transparent) const {
-    if(Q_LIKELY(!transparent)) {
-        if(Q_UNLIKELY(qicon_.isNull() && gicon_)) {
-            if(!G_IS_FILE_ICON(gicon_.get())) {
-                qicon_ = QIcon(new IconEngine{shared_from_this()});
-            }
-            else {
-                qicon_ = getFirst(internalQicons_);
-            }
+QIcon IconInfo::qicon() const {
+    if(Q_UNLIKELY(qicon_.isNull() && gicon_)) {
+        if(!G_IS_FILE_ICON(gicon_.get())) {
+            qicon_ = QIcon(new IconEngine{shared_from_this()});
+        }
+        else {
+            qicon_ = getFirst(internalQicons_);
         }
     }
-    else { // transparent == true
-        if(Q_UNLIKELY(qiconTransparent_.isNull() && gicon_)) {
-            if(!G_IS_FILE_ICON(gicon_.get())) {
-                qiconTransparent_ = QIcon(new IconEngine{shared_from_this(), transparent});
-            }
-            else {
-                qiconTransparent_ = getFirst(internalQicons_);
-            }
-        }
-    }
-    return !transparent ? qicon_ : qiconTransparent_;
+    return qicon_;
 }
 
 QList<QIcon> IconInfo::qiconsFromNames(const char* const* names) {

--- a/src/core/iconinfo.h
+++ b/src/core/iconinfo.h
@@ -63,7 +63,7 @@ public:
         return gicon_;
     }
 
-    QIcon qicon(const bool& transparent = false) const;
+    QIcon qicon() const;
 
     bool hasEmblems() const {
         return G_IS_EMBLEMED_ICON(gicon_.get());
@@ -97,7 +97,6 @@ private:
 private:
     GIconPtr gicon_;
     mutable QIcon qicon_;
-    mutable QIcon qiconTransparent_;
     mutable QList<QIcon> internalQicons_;
 
     static std::unordered_map<GIcon*, std::shared_ptr<IconInfo>, GIconHash, GIconEqual> cache_;

--- a/src/core/iconinfo_p.h
+++ b/src/core/iconinfo_p.h
@@ -31,7 +31,7 @@ namespace Fm {
 class IconEngine: public QIconEngine {
 public:
 
-    IconEngine(std::shared_ptr<const Fm::IconInfo> info, const bool& transparent = false);
+    IconEngine(std::shared_ptr<const Fm::IconInfo> info);
 
     ~IconEngine() override;
 
@@ -55,11 +55,9 @@ public:
 
 private:
     std::weak_ptr<const Fm::IconInfo> info_;
-    bool transparent_;
 };
 
-IconEngine::IconEngine(std::shared_ptr<const IconInfo> info, const bool& transparent):
-    info_{info}, transparent_{transparent} {
+IconEngine::IconEngine(std::shared_ptr<const IconInfo> info): info_{info} {
 }
 
 IconEngine::~IconEngine() {
@@ -82,14 +80,7 @@ QString IconEngine::key() const {
 void IconEngine::paint(QPainter* painter, const QRect& rect, QIcon::Mode mode, QIcon::State state) {
     auto info = info_.lock();
     if(info) {
-        if(transparent_) {
-            painter->save();
-            painter->setOpacity(0.45);
-        }
         info->internalQicon().paint(painter, rect, Qt::AlignCenter, mode, state);
-        if(transparent_) {
-            painter->restore();
-        }
     }
 }
 

--- a/src/foldermodel.h
+++ b/src/foldermodel.h
@@ -110,7 +110,6 @@ protected Q_SLOTS:
     void onFinishLoading();
     void onFilesAdded(const Fm::FileInfoList& files);
     void onFilesChanged(std::vector<Fm::FileInfoPair>& files);
-    void onCutFilesChanged(std::vector<Fm::FileInfoPair>& files);
     void onFilesRemoved(const Fm::FileInfoList& files);
 
     void onThumbnailLoaded(const std::shared_ptr<const Fm::FileInfo>& file, int size, const QImage& image);
@@ -127,8 +126,8 @@ protected:
     QList<FolderModelItem>::iterator findItemByFileInfo(const Fm::FileInfo* info, int* row);
 
 private:
-    void setCutFiles(const Fm::FilePathList& paths);
     QString makeTooltip(FolderModelItem* item) const;
+    void updateCutFilesSet();
 
 private:
 
@@ -153,6 +152,9 @@ private:
     bool showFullNames_;
 
     bool isLoaded_;
+
+    bool hasCutfile_;
+    HashSet cutFilesHashSet_;
 };
 
 }

--- a/src/foldermodelitem.h
+++ b/src/foldermodelitem.h
@@ -43,7 +43,6 @@ public:
 
     struct Thumbnail {
         int size;
-        bool transparent;
         ThumbnailStatus status;
         QImage image;
     };
@@ -61,9 +60,9 @@ public:
         return info->name();
     }
 
-    QIcon icon(bool transparent = false) const {
+    QIcon icon() const {
         const auto i = info->icon();
-        return i ? i->qicon(transparent) : QIcon{};
+        return i ? i->qicon() : QIcon{};
     }
 
     QString ownerName() const;
@@ -76,9 +75,7 @@ public:
 
     const QString &displaySize() const;
 
-    bool isCut() const;
-
-    Thumbnail* findThumbnail(int size, bool transparent);
+    Thumbnail* findThumbnail(int size);
 
     void removeThumbnail(int size);
 
@@ -87,6 +84,7 @@ public:
     mutable QString dispDtime_;
     mutable QString dispSize_;
     QVector<Thumbnail> thumbnails;
+    bool isCut;
 };
 
 }

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -43,8 +43,6 @@ LIBFM_QT_API QByteArray pathListToUriList(const Fm::FilePathList& paths);
 
 LIBFM_QT_API Fm::FilePathList pathListFromQUrls(QList<QUrl> urls);
 
-LIBFM_QT_API std::pair<Fm::FilePathList, bool> parseClipboardData(const QMimeData& data);
-
 LIBFM_QT_API void pasteFilesFromClipboard(const Fm::FilePath& destPath, QWidget* parent = nullptr);
 
 LIBFM_QT_API void copyFilesToClipboard(const Fm::FilePathList& files);


### PR DESCRIPTION
The current patch simplifies and enhances the graying-out of cut files considerably by removing all traces of cut files from the core of libfm-qt and doing the job at the level of `FolderModel`. In this way, a better functionality is achieved by a much simpler logic.

Since a hash set is used for tracking cut files (instead of a path vector), the CPU usage is negligible even with huge numbers of cut files.

In addition:

 * The patch grays out cut files in multiple folders too (e.g., when multiple files are cut from a recursive search result).
 * Cut files are also grayed out in folders without file monitor (except for `search://`, which isn't a real folder).

WARNING: The changes affect both ABI and API. Therefore, **pcmanfm-qt and all other libfm-qt based apps should be cleanly recompiled after this.**

Closes https://github.com/lxqt/libfm-qt/issues/563