### PR TITLE
File dialog: open mount targets of mountable directories

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -696,7 +696,13 @@ void FileDialog::onFileClicked(int type, const std::shared_ptr<const FileInfo> &
                 ui->fileName->clear();
             }
             // chdir into the activated dir
-            setDirectoryPath(file->path());
+            if(file->isMountable() && !file->target().empty()) {
+                // a mounted mountable directory (like computer:///root.link)
+                setDirectoryPath(FilePath::fromPathStr(file->target().c_str()));
+            }
+            else {
+                setDirectoryPath(file->path());
+            }
         }
         else if(fileMode_ != QFileDialog::Directory) {
             // select file(s) and a file item is activated


### PR DESCRIPTION
Previously, the mount targets weren't checked and, for example, `computer:///root.link` was opened as an empty directory.

Closes https://github.com/lxqt/libfm-qt/issues/565