### PR TITLE
File dialog: Added options for thumbnails, tooltips and icon sizes

### DIFF
--- a/src/filedialog.h
+++ b/src/filedialog.h
@@ -147,6 +147,23 @@ public:
     }
     void setHiddenPlaces(const QSet<QString>& items);
 
+    bool showThumbnails() const;
+    void setShowThumbnails(bool show);
+
+    bool noItemTooltip() const {
+        return noItemTooltip_;
+    }
+    void setNoItemTooltip(bool noItemTooltip);
+
+    int bigIconSize() const;
+    void setBigIconSize(int size);
+
+    int smallIconSize() const;
+    void setSmallIconSize(int size);
+
+    int thumbnailIconSize() const;
+    void setThumbnailIconSize(int size);
+
 protected:
     bool eventFilter(QObject* watched, QEvent* event) override;
 
@@ -238,9 +255,9 @@ private:
     QAction* forwardAction_;
     // dialog labels that can be set explicitly:
     QString explicitLabels_[5];
-    // needed for disconnecting Fm::Folder signal from lambda:
-    QMetaObject::Connection lambdaConnection_;
+    QMetaObject::Connection lambdaConnection_; // needed for disconnecting Fm::Folder signal from lambda:
     QSet<QString> hiddenPlaces_;
+    bool noItemTooltip_;
 };
 
 

--- a/src/filedialog_p.h
+++ b/src/filedialog_p.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2014 - 2015  Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef FM_FILEDIALOG_P_H
+#define FM_FILEDIALOG_P_H
+
+#include <QWidgetAction>
+#include <QLabel>
+#include <QSpinBox>
+#include <QHBoxLayout>
+
+namespace Fm {
+
+class FileDialogIconSizeAction : public QWidgetAction {
+    Q_OBJECT
+public:
+    FileDialogIconSizeAction(const QString& text, QObject* parent) : QWidgetAction (parent) {
+        QWidget* w = new QWidget();
+        QHBoxLayout* layout = new QHBoxLayout();
+        layout->setSpacing(4);
+        QLabel* label = new QLabel(text);
+        layout->addWidget(label);
+        spinBox = new QSpinBox();
+        spinBox->setSuffix(tr(" px"));
+        spinBox->setSingleStep(2);
+        layout->addWidget(spinBox);
+        w->setLayout(layout);
+        setDefaultWidget(w);
+
+        connect(spinBox, &QAbstractSpinBox::editingFinished, this, &FileDialogIconSizeAction::editingFinished);
+    }
+
+    int value() const {
+        return spinBox->value();
+    }
+    void setValue(int val) {
+        spinBox->setValue(val);
+    }
+
+    void setBounds(int min, int max) {
+        spinBox->setMinimum(min);
+        spinBox->setMaximum(max);
+    }
+
+    void setSingleStep(int val) {
+        spinBox->setSingleStep(val);
+    }
+
+Q_SIGNALS:
+    void editingFinished();
+
+private:
+    QSpinBox* spinBox;
+};
+
+
+} // namespace Fm
+#endif // FM_FILEDIALOG_P_H

--- a/src/filedialoghelper.cpp
+++ b/src/filedialoghelper.cpp
@@ -314,6 +314,13 @@ void FileDialogHelper::loadSettings() {
    dlg_->setSortHiddenLast(settings.value(QStringLiteral("SortHiddenLast"), false).toBool());
    dlg_->setSortCaseSensitive(settings.value(QStringLiteral("SortCaseSensitive"), false).toBool());
    dlg_->setShowHidden(settings.value(QStringLiteral("ShowHidden"), false).toBool());
+
+   dlg_->setShowThumbnails(settings.value(QStringLiteral("ShowThumbnails"), true).toBool());
+   dlg_->setNoItemTooltip(settings.value(QStringLiteral("NoItemTooltip"), false).toBool());
+
+   dlg_->setBigIconSize(settings.value(QStringLiteral("BigIconSize"), 48).toInt());
+   dlg_->setSmallIconSize(settings.value(QStringLiteral("SmallIconSize"), 24).toInt());
+   dlg_->setThumbnailIconSize(settings.value(QStringLiteral("ThumbnailIconSize"), 128).toInt());
    settings.endGroup();
 
    settings.beginGroup(QStringLiteral("Places"));
@@ -363,6 +370,28 @@ void FileDialogHelper::saveSettings() {
     bool showHidden = dlg_->showHidden();
     if(settings.value(QStringLiteral("ShowHidden")).toBool() != showHidden) {
         settings.setValue(QStringLiteral("ShowHidden"), showHidden);
+    }
+
+    bool showThumbnails = dlg_->showThumbnails();
+    if(settings.value(QStringLiteral("ShowThumbnails")).toBool() != showThumbnails) {
+        settings.setValue(QStringLiteral("ShowThumbnails"), showThumbnails);
+    }
+    bool noItemTooltip = dlg_->noItemTooltip();
+    if(settings.value(QStringLiteral("NoItemTooltip")).toBool() != noItemTooltip) {
+        settings.setValue(QStringLiteral("NoItemTooltip"), noItemTooltip);
+    }
+
+    int size = dlg_->bigIconSize();
+    if(settings.value(QStringLiteral("BigIconSize")).toInt() != size) {
+        settings.setValue(QStringLiteral("BigIconSize"), size);
+    }
+    size = dlg_->smallIconSize();
+    if(settings.value(QStringLiteral("SmallIconSize")).toInt() != size) {
+        settings.setValue(QStringLiteral("SmallIconSize"), size);
+    }
+    size = dlg_->thumbnailIconSize();
+    if(settings.value(QStringLiteral("ThumbnailIconSize")).toInt() != size) {
+        settings.setValue(QStringLiteral("ThumbnailIconSize"), size);
     }
     settings.endGroup();
 


### PR DESCRIPTION
And put all view options inside menus.

NOTE: pcmanfm-qt and lxqt-archiver should be recompiled but, to be on the safe side, recompile lximage-qt (and other libfm-qt based apps) too.

Closes https://github.com/lxqt/libfm-qt/issues/349