### PR TITLE
Natural (GTK-like) file sorting by treating dot as separator

### DIFF
--- a/src/proxyfoldermodel.cpp
+++ b/src/proxyfoldermodel.cpp
@@ -185,9 +185,27 @@ bool ProxyFolderModel::lessThan(const QModelIndex& left, const QModelIndex& righ
             }
             break;
         default: {
+            // To have a more natural sorting like that of GTK, we consider dot
+            // as a separator and compare sub-strings from left to right.
+            // QString::split() is not used because some dots may not be needed.
             QString leftText = left.data(Qt::DisplayRole).toString();
             QString rightText = right.data(Qt::DisplayRole).toString();
-            comp = collator_.compare(leftText, rightText);
+            int leftStart = 0, rightStart = 0;
+            int leftEnd = 0, rightEnd = 0;
+            for(;;) {
+                leftEnd = leftText.indexOf(QLatin1Char('.'), leftStart);
+                rightEnd = rightText.indexOf(QLatin1Char('.'), rightStart);
+                comp = collator_.compare(leftText.mid(leftStart, leftEnd - leftStart),
+                                         rightText.mid(rightStart, rightEnd - rightStart));
+                if(comp != 0 || leftEnd == -1 || rightEnd == -1) {
+                    break;
+                }
+                leftStart = leftEnd + 1;
+                rightStart = rightEnd + 1;
+            }
+            if(comp == 0) {
+                comp = leftEnd - rightEnd; // covers all remaining cases
+            }
             break;
         }
         }


### PR DESCRIPTION
Qt's default sorting can be counterintuitive for files (e.g., `a_1.txt` comes before `a.txt` with the ascending order). This patch sorts files by treating dot as a separator and comparing split strings with each other.

This is exactly how GTK (file dialog) sorts files; it considers all dots as separators (not just the last dot) and treats folders like files. Most Linux users are accustomed to GTK's file sorting, which is generally more intuitive than Qt's.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1201