### PR TITLE
Also Update cut files when entering a loaded folder

### DIFF
--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -68,6 +68,7 @@ void FolderModel::setFolder(const std::shared_ptr<Fm::Folder>& new_folder) {
         if(folder_->isLoaded()) {
             isLoaded_ = true;
             insertFiles(0, folder_->files());
+            onClipboardDataChange(); // files may have been cut
         }
     }
 }


### PR DESCRIPTION
Because the folder may have been loaded with a separate `FolderModel` in the same app.

The following bug is fixed:

 1. Open a single pcmanfm-qt window and change directory to the desktop.
 2. Cut a file in the desktop from inside the window.
 3. Close the window, open it and change directory to the desktop again.

Then the cut file won't be grayed out without this fix (until the folder is reloaded) because the desktop is loaded in the background with a separate `FolderModel` (without `CachedFolderModel`).