### PR TITLE
Support special chars like `\n` and `\t` in path button name

### DIFF
--- a/src/pathbar_p.h
+++ b/src/pathbar_p.h
@@ -44,7 +44,7 @@ public:
         int icnSize = style()->pixelMetric(QStyle::PM_ToolBarIconSize);
         setIconSize(QSize(icnSize, icnSize));
 
-        setText(displayName);
+        setText(displayName.replace(QLatin1Char('\n'), QLatin1Char(' '))); // single-line text
 
         if(isRoot) { /* this element is root */
             QIcon icon = QIcon::fromTheme(QStringLiteral("drive-harddisk"));
@@ -69,7 +69,6 @@ public:
     }
 
 private:
-    QString displayName_;
     std::string name_;
 };
 


### PR DESCRIPTION
Previously, `\n` and `\t` weren't supported and so, folders couldn't be opened by path buttons if their names included `\t` or `\n`.

Also:

 * Always give single-line texts to path buttons.
 * Handle ampersands in button names (don't mistake them for mnemonics).

NOTE: QTabBar has a bug that elides tab texts when they includes `\t`. Also, styles like Fusion and Breeze have problem with several newlines in tab texts. None of these problems is related to the current patch or can be worked around here.

Fixes https://github.com/lxqt/libfm-qt/issues/572