### PR TITLE
Fix compiling with Qt >=5.15.3

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -1109,7 +1109,7 @@ void FileDialog::setMimeTypeFilters(const QStringList& filters) {
                 nameFilter += suffix;
                 nameFilter += QLatin1Char(' ');
             }
-            nameFilter[nameFilter.length() - 1] = ')';
+            nameFilter[nameFilter.length() - 1] = QLatin1Char(')');
         }
         nameFilters << nameFilter;
     }


### PR DESCRIPTION
Not sure at all if this is the correct way to fix this, but at least it builds, and I haven't noticed anything broken thus far.  :]

I imagine it will compile on lower versions as well, but I have not tested that.

The failure looks like this:

```
/src/filedialog.cpp: In member function ‘void Fm::FileDialog::setMimeTypeFilters(const QStringList&)’:
/src/filedialog.cpp:1112:51: error: use of deleted function ‘QCharRef& QCharRef::operator=(char)’
 1112 |             nameFilter[nameFilter.length() - 1] = ')';
      |                                                   ^~~
In file included from /usr/include/qt5/QtCore/qhashfunctions.h:44,
                 from /usr/include/qt5/QtCore/qlist.h:47,
                 from /usr/include/qt5/QtCore/qhash.h:46,
                 from /usr/include/qt5/QtCore/qdebug.h:45,
                 from /usr/include/qt5/QtCore/QDebug:1,
                 from /src/core/gobjectptr.h:8,
                 from /src/core/filepath.h:5,
                 from /src/filedialog.h:5,
                 from /src/filedialog.cpp:1:
/usr/include/qt5/QtCore/qstring.h:1236:15: note: declared here
 1236 |     QCharRef &operator=(char c) = delete;
      |               ^~~~~~~~
```
