### PR TITLE
Add Alacritty to terminal list

### DIFF
--- a/data/terminals.list
+++ b/data/terminals.list
@@ -81,3 +81,8 @@ desktop_id=kitty.desktop
 
 [st]
 open_arg=-e
+
+[alacritty]
+open_arg=-e
+noclose_arg=--hold -e
+desktop_id=Alacritty.desktop


### PR DESCRIPTION
Add support for Alacritty terminal emulator (https://github.com/alacritty/alacritty)