### PR TITLE
Fixed template renaming before creating

### DIFF
--- a/src/core/filetransferjob.h
+++ b/src/core/filetransferjob.h
@@ -50,6 +50,7 @@ private:
     FilePathList srcPaths_;
     FilePathList destPaths_;
     Mode mode_;
+    bool hasDestDirPath_;
 };
 
 


### PR DESCRIPTION
Templates couldn't be renamed before creation because GLib's "copy-name" was always used to copy files. That's not only good but also necessary *as far as destination file names aren't given explicitly*, while they are in the case of template renaming.

Therefore, the two kinds of file copying are distinguished from each other: (1) When only the destination folder is given (which covers most cases) and (2) When the destination file names are specified (copy + rename). That's done simply by using an extra boolean variable.

Fixes https://github.com/lxqt/pcmanfm-qt/issues/1253

NOTE: To be on the safe side, recompile pcmanfm-qt, although it shouldn't be needed theoretically.