### PR TITLE
Fixed a rare crash on emptying Trash

### DIFF
--- a/src/fileoperation.cpp
+++ b/src/fileoperation.cpp
@@ -109,6 +109,11 @@ FileOperation::~FileOperation() {
         delete elapsedTimer_;
         elapsedTimer_ = nullptr;
     }
+    if(dlg_) {
+        dlg_->done(QDialog::Accepted);
+        delete dlg_;
+        dlg_ = nullptr;
+    }
 }
 
 void FileOperation::setDestination(Fm::FilePath dest) {

--- a/src/placesview.cpp
+++ b/src/placesview.cpp
@@ -332,7 +332,7 @@ void PlacesView::dropEvent(QDropEvent* event) {
 void PlacesView::onEmptyTrash() {
     Fm::FilePathList files;
     files.push_back(Fm::FilePath::fromUri("trash:///"));
-    Fm::FileOperation::deleteFiles(std::move(files), true, this);
+    Fm::FileOperation::deleteFiles(std::move(files), true);
 }
 
 void PlacesView::onMoveBookmarkUp() {


### PR DESCRIPTION
This patch includes two interrelated fixes:

 1. The side-pane shouldn't be the parent object of the trash emptying operation because, otherwise, the operation might remain incomplete if the window is closed too soon.
 2. Most importantly, the file operation should close and delete the operation dialog in its destructor; otherwise, a crash will be imminent because the operation dialog will cancel a deleted job if it's closed or its Cancel button is clicked after the job is destroyed.

Fixes https://github.com/lxqt/libfm-qt/issues/603