### PR TITLE
Added support for creation time

### DIFF
--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -262,6 +262,7 @@ _file_is_symlink:
     mtime_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_TIME_MODIFIED);
     atime_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_TIME_ACCESS);
     ctime_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_TIME_CHANGED);
+    crtime_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_TIME_CREATED);
     if(auto dt = g_file_info_get_deletion_date(inf.get())){
         dtime_ = g_date_time_to_unix(dt);
     }

--- a/src/core/fileinfo.h
+++ b/src/core/fileinfo.h
@@ -93,6 +93,9 @@ public:
         return ctime_;
     }
 
+    quint64 crtime() const {
+        return crtime_;
+    }
 
     quint64 atime() const {
         return atime_;
@@ -234,6 +237,7 @@ private:
     quint64 mtime_;
     quint64 atime_;
     quint64 ctime_;
+    quint64 crtime_;
     quint64 dtime_;
 
     uint64_t blksize_;

--- a/src/file-props.ui
+++ b/src/file-props.ui
@@ -276,20 +276,37 @@
         </widget>
        </item>
        <item row="10" column="0">
+        <widget class="QLabel" name="label_13">
+         <property name="text">
+          <string>Created:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1">
+        <widget class="QLabel" name="created">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
         <widget class="QLabel" name="contentsLabel">
          <property name="text">
           <string>Contains:</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="11" column="1">
         <widget class="QLabel" name="fileNumber">
          <property name="text">
           <string/>
          </property>
         </widget>
        </item>
-       <item row="11" column="0">
+       <item row="12" column="0">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -305,7 +322,7 @@
          </property>
         </spacer>
        </item>
-       <item row="12" column="0" colspan="2">
+       <item row="13" column="0" colspan="2">
         <layout class="QGridLayout" name="gridLayout_3">
          <property name="horizontalSpacing">
           <number>10</number>

--- a/src/filedialoghelper.cpp
+++ b/src/filedialoghelper.cpp
@@ -249,6 +249,9 @@ static Fm::FolderModel::ColumnId sortColumnFromString(const QString str) {
     else if(str == QLatin1String("mtime")) {
         ret = Fm::FolderModel::ColumnFileMTime;
     }
+    else if(str == QLatin1String("crtime")) {
+        ret = Fm::FolderModel::ColumnFileCrTime;
+    }
     else if(str == QLatin1String("dtime")) {
         ret = Fm::FolderModel::ColumnFileDTime;
     }
@@ -279,6 +282,9 @@ static const QString sortColumnToString(Fm::FolderModel::ColumnId value) {
         break;
     case Fm::FolderModel::ColumnFileMTime:
         ret = QLatin1String("mtime");
+        break;
+    case Fm::FolderModel::ColumnFileCrTime:
+        ret = QLatin1String("crtime");
         break;
     case Fm::FolderModel::ColumnFileDTime:
         ret = QLatin1String("dtime");

--- a/src/filepropsdialog.cpp
+++ b/src/filepropsdialog.cpp
@@ -305,6 +305,8 @@ void FilePropsDialog::initGeneralPage() {
         ui->lastModified->setText(mtime.toString(Qt::SystemLocaleShortDate));
         auto atime = QDateTime::fromMSecsSinceEpoch(fileInfo->atime() * 1000);
         ui->lastAccessed->setText(atime.toString(Qt::SystemLocaleShortDate));
+        auto crtime = QDateTime::fromMSecsSinceEpoch(fileInfo->crtime() * 1000);
+        ui->created->setText(crtime.toString(Qt::SystemLocaleShortDate));
     }
     else {
         ui->fileName->setText(tr("Multiple Files"));

--- a/src/foldermenu.cpp
+++ b/src/foldermenu.cpp
@@ -162,6 +162,7 @@ void FolderMenu::createSortMenu() {
 
     addSortMenuItem(tr("By File Name"), FolderModel::ColumnFileName);
     addSortMenuItem(tr("By Modification Time"), FolderModel::ColumnFileMTime);
+    addSortMenuItem(tr("By Creation Time"), FolderModel::ColumnFileCrTime);
     if(auto folderPath = view_->path()) {
         if(strcmp(folderPath.toString().get(), "trash:///") == 0) {
             addSortMenuItem(tr("By Deletion Time"), FolderModel::ColumnFileDTime);

--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -295,6 +295,7 @@ std::shared_ptr<const Fm::FileInfo> FolderModel::fileInfoFromIndex(const QModelI
 QString FolderModel::makeTooltip(FolderModelItem* item) const {
     // name (bold)
     QString tip = QStringLiteral("<p><b>") + (showFullNames_ ? QString::fromStdString(item->name()) : item->displayName()).toHtmlEscaped() + QStringLiteral("</b></p>");
+
     // parent dir
     auto info = item->info;
     auto parent_path = info->path().parent();
@@ -302,23 +303,29 @@ QString FolderModel::makeTooltip(FolderModelItem* item) const {
     if(parent_str) {
         tip += QStringLiteral("<p><i>") + tr("Location:") + QStringLiteral("</i> ") + QString::fromUtf8(parent_str.get()).toHtmlEscaped() + QStringLiteral("</p>");
     }
+
     // file type
     tip += QStringLiteral("<i>") + tr("File type:") + QStringLiteral("</i> ") + QString::fromUtf8(info->mimeType()->desc());
+
     // file size
     const QString dSize = item->displaySize();
     if(!dSize.isEmpty()) { // it's empty for directories
         tip += QStringLiteral("<br><i>") + tr("File size:") + QStringLiteral("</i> ") + dSize;
     }
+
     // times
     auto atime = QDateTime::fromMSecsSinceEpoch(info->atime() * 1000);
     tip += QStringLiteral("<br><i>") + tr("Last modified:") + QStringLiteral("</i> ") + item->displayMtime()
-           + QStringLiteral("<br><i>") + tr("Last accessed:") + QStringLiteral("</i> ") + atime.toString(Qt::SystemLocaleShortDate);
+           + QStringLiteral("<br><i>") + tr("Last accessed:") + QStringLiteral("</i> ") + atime.toString(Qt::SystemLocaleShortDate)
+           + QStringLiteral("<br><i>") + tr("Created:") + QStringLiteral("</i> ") + item->displayCrtime();
+
     // owner
     const QString owner = item->ownerName();
     if(!owner.isEmpty()) { // can be empty
         tip += QStringLiteral("<br><i>") + tr("Owner:") + QStringLiteral("</i> ") + owner
                + QStringLiteral("<br><i>") + tr("Group:") + QStringLiteral("</i> ") + item->ownerGroup();
     }
+
     return tip;
 }
 
@@ -342,6 +349,8 @@ QVariant FolderModel::data(const QModelIndex& index, int role/* = Qt::DisplayRol
             return QString::fromUtf8(info->mimeType()->desc());
         case ColumnFileMTime:
             return item->displayMtime();
+        case ColumnFileCrTime:
+            return item->displayCrtime();
         case ColumnFileDTime:
             return item->displayDtime();
         case ColumnFileSize:
@@ -391,6 +400,9 @@ QVariant FolderModel::headerData(int section, Qt::Orientation orientation, int r
                 break;
             case ColumnFileMTime:
                 title = tr("Modified");
+                break;
+            case ColumnFileCrTime:
+                title = tr("Created");
                 break;
             case ColumnFileDTime:
                 title = tr("Deleted");

--- a/src/foldermodel.h
+++ b/src/foldermodel.h
@@ -52,6 +52,7 @@ public:
         ColumnFileType,
         ColumnFileSize,
         ColumnFileMTime,
+        ColumnFileCrTime,
         ColumnFileDTime,
         ColumnFileOwner,
         ColumnFileGroup,

--- a/src/foldermodelitem.cpp
+++ b/src/foldermodelitem.cpp
@@ -63,6 +63,14 @@ const QString &FolderModelItem::displayMtime() const {
     return dispMtime_;
 }
 
+const QString &FolderModelItem::displayCrtime() const {
+    if(dispCrtime_.isEmpty()) {
+        auto crtime = QDateTime::fromMSecsSinceEpoch(info->crtime() * 1000);
+        dispCrtime_ = crtime.toString(Qt::SystemLocaleShortDate);
+    }
+    return dispCrtime_;
+}
+
 const QString &FolderModelItem::displayDtime() const {
     if(dispDtime_.isEmpty() && info->dtime() > 0) {
         auto mtime = QDateTime::fromMSecsSinceEpoch(info->dtime() * 1000);

--- a/src/foldermodelitem.h
+++ b/src/foldermodelitem.h
@@ -71,6 +71,8 @@ public:
 
     const QString& displayMtime() const;
 
+    const QString& displayCrtime() const;
+
     const QString& displayDtime() const;
 
     const QString &displaySize() const;
@@ -81,6 +83,7 @@ public:
 
     std::shared_ptr<const Fm::FileInfo> info;
     mutable QString dispMtime_;
+    mutable QString dispCrtime_;
     mutable QString dispDtime_;
     mutable QString dispSize_;
     QVector<Thumbnail> thumbnails;

--- a/src/proxyfoldermodel.cpp
+++ b/src/proxyfoldermodel.cpp
@@ -173,6 +173,11 @@ bool ProxyFolderModel::lessThan(const QModelIndex& left, const QModelIndex& righ
                 return leftInfo->mtime() < rightInfo->mtime();
             }
             break;
+        case FolderModel::ColumnFileCrTime:
+            if(leftInfo->crtime() != rightInfo->crtime()) { // quint64
+                return leftInfo->crtime() < rightInfo->crtime();
+            }
+            break;
         case FolderModel::ColumnFileSize:
             if(leftInfo->size() != rightInfo->size()) { // quint64
                 return leftInfo->size() < rightInfo->size();


### PR DESCRIPTION
GLib is responsible for reporting the correct creation time. Closes https://github.com/lxqt/libfm-qt/issues/397

WARNING: All libfm-qt based apps should be recompiled.

NOTE: This PR will be followed by another for pcmanfm-qt to complete the support for creation time.