### PR TITLE
File dialog: Allow opening of desktop files that are shortcuts

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -924,9 +924,9 @@ void FileDialog::onFileInfoJobFinished() {
                     break;
                 }
             }
-            else if(file->isDir() || file->isShortcut()) {
+            else if(file->isDir() || (file->isShortcut() && !file->isDesktopEntry())) {
                 // we're selecting files, but the selected file path refers to a dir or shortcut (such as computer:///)
-                error = tr("\"%1\" is not a file").arg(QString::fromUtf8(path.displayName().get()));;
+                error = tr("\"%1\" is not a file").arg(QString::fromUtf8(path.displayName().get()));
                 break;
             }
         }


### PR DESCRIPTION
Previously, LXQt file dialog didn't open any shortcut (in contrast to symlinks) but desktop files are text files.

Closes https://github.com/lxqt/libfm-qt/issues/629