### PR TITLE
Workaround for a bug in QCollator when sorting files

### DIFF
--- a/src/proxyfoldermodel.cpp
+++ b/src/proxyfoldermodel.cpp
@@ -189,8 +189,14 @@ bool ProxyFolderModel::lessThan(const QModelIndex& left, const QModelIndex& righ
             for(;;) {
                 leftEnd = leftText.indexOf(QLatin1Char('.'), leftStart);
                 rightEnd = rightText.indexOf(QLatin1Char('.'), rightStart);
-                comp = collator_.compare(leftText.mid(leftStart, leftEnd - leftStart),
-                                         rightText.mid(rightStart, rightEnd - rightStart));
+                QStringRef lefPart = leftText.midRef(leftStart, leftEnd - leftStart);
+                QStringRef rightPart = rightText.midRef(rightStart, rightEnd - rightStart);
+                comp = collator_.compare(lefPart, rightPart);
+                if(comp == 0) {
+                    // This is a workaround for QCollator's behavior that, for example,
+                    // considers "A0" and "A00" equal when the numeric mode is enabled.
+                    comp = lefPart.size() - rightPart.size();
+                }
                 if(comp != 0 || leftEnd == -1 || rightEnd == -1) {
                     break;
                 }


### PR DESCRIPTION
For example, QCollator sees `A01` and `A1` equal when its numeric mode is enabled.

This patch follows GTK's approach (which was already adopted for extensions) and considers `A1` less than `A01` in the numeric mode by comparing their sizes.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1312