### PR TITLE
Removed redundant context menu items inside Trash

### DIFF
--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -56,6 +56,7 @@ FileMenu::FileMenu(Fm::FileInfoList files, std::shared_ptr<const Fm::FileInfo> i
     openAction_ = nullptr;
     openWithMenuAction_ = nullptr;
     openWithAction_ = nullptr;
+    createAction_ = nullptr;
     separator1_ = nullptr;
     cutAction_ = nullptr;
     copyAction_ = nullptr;
@@ -140,12 +141,13 @@ FileMenu::FileMenu(Fm::FileInfoList files, std::shared_ptr<const Fm::FileInfo> i
 
     separator1_ = addSeparator();
 
-    createAction_ = new QAction(tr("Create &New"), this);
-    Fm::FilePath dirPath = files_.size() == 1 && info_->isDir() ? path : cwd_;
-    createAction_->setMenu(new CreateNewMenu(parent, dirPath, this));
-    addAction(createAction_);
-
-    separator2_ = addSeparator();
+    if(!allTrash_) {
+        createAction_ = new QAction(tr("Create &New"), this);
+        Fm::FilePath dirPath = files_.size() == 1 && info_->isDir() ? path : cwd_;
+        createAction_->setMenu(new CreateNewMenu(parent, dirPath, this));
+        addAction(createAction_);
+        separator2_ = addSeparator();
+    }
 
     if(allTrash_) { // all selected files are in trash:///
         bool can_restore = true;
@@ -210,7 +212,9 @@ FileMenu::FileMenu(Fm::FileInfoList files, std::shared_ptr<const Fm::FileInfo> i
         if(!(sameType_ && info_->isDir()
              && (files_.size() > 1 ? isWritableDir : info_->isWritable()))) {
             pasteAction_->setEnabled(false);
-            createAction_->setEnabled(false);
+            if(createAction_) {
+                createAction_->setEnabled(false);
+            }
         }
     }
 
@@ -229,7 +233,7 @@ FileMenu::FileMenu(Fm::FileInfoList files, std::shared_ptr<const Fm::FileInfo> i
 
     // archiver integration
     // FIXME: we need to modify upstream libfm to include some Qt-based archiver programs.
-    if(!allVirtual_) {
+    if(!allVirtual_ && !allTrash_) {
         auto archiver = Archiver::defaultArchiver();
         if(archiver) {
             if(sameType_ && archiver->isMimeTypeSupported(mime_type->name())) {

--- a/src/foldermenu.cpp
+++ b/src/foldermenu.cpp
@@ -36,20 +36,25 @@ FolderMenu::FolderMenu(FolderView* view, QWidget* parent):
     QMenu(parent),
     view_(view) {
 
+    createAction_ = nullptr;
+    pasteAction_ = nullptr;
+    separator1_ = nullptr;
+    separator2_ = nullptr;
+
     ProxyFolderModel* model = view_->model();
 
-    createAction_ = new QAction(tr("Create &New"), this);
-    addAction(createAction_);
+    bool insideTrash(view_->path() && view_->path().hasUriScheme("trash"));
+    if(!insideTrash) {
+        createAction_ = new QAction(tr("Create &New"), this);
+        addAction(createAction_);
+        createAction_->setMenu(new CreateNewMenu(view_, view_->path(), this));
+        separator1_ = addSeparator();
 
-    createAction_->setMenu(new CreateNewMenu(view_, view_->path(), this));
-
-    separator1_ = addSeparator();
-
-    pasteAction_ = new QAction(QIcon::fromTheme(QStringLiteral("edit-paste")), tr("&Paste"), this);
-    addAction(pasteAction_);
-    connect(pasteAction_, &QAction::triggered, this, &FolderMenu::onPasteActionTriggered);
-
-    separator2_ = addSeparator();
+        pasteAction_ = new QAction(QIcon::fromTheme(QStringLiteral("edit-paste")), tr("&Paste"), this);
+        addAction(pasteAction_);
+        connect(pasteAction_, &QAction::triggered, this, &FolderMenu::onPasteActionTriggered);
+        separator2_ = addSeparator();
+    }
 
     selectAllAction_ = new QAction(tr("Select &All"), this);
     addAction(selectAllAction_);
@@ -89,8 +94,12 @@ FolderMenu::FolderMenu(FolderView* view, QWidget* parent):
         }
 
         // disable actons that can't be used
-        pasteAction_->setEnabled(folderInfo->isWritable());
-        createAction_->setEnabled(folderInfo->isWritable());
+        if(pasteAction_) {
+            pasteAction_->setEnabled(folderInfo->isWritable());
+        }
+        if(createAction_) {
+            createAction_->setEnabled(folderInfo->isWritable());
+        }
     }
 
     separator4_ = addSeparator();


### PR DESCRIPTION
NOTE: I left "Open" and "Open With..." for non-folders as they were because some apps may be able to open trashed files.

Closes https://github.com/lxqt/libfm-qt/issues/636