### PR TITLE
Set a separate file size limit for external thumbnails

### DIFF
--- a/src/core/legacy/fm-config.c
+++ b/src/core/legacy/fm-config.c
@@ -56,6 +56,7 @@ void fm_config_init() {
     self->show_thumbnail = FM_CONFIG_DEFAULT_SHOW_THUMBNAIL;
     self->thumbnail_local = FM_CONFIG_DEFAULT_THUMBNAIL_LOCAL;
     self->thumbnail_max = FM_CONFIG_DEFAULT_THUMBNAIL_MAX;
+    self->external_thumbnail_max = FM_CONFIG_DEFAULT_EXTERNAL_THUMBNAIL_MAX;
     /* show_internal_volumes defaulted to FALSE */
     /* si_unit defaulted to FALSE */
     /* terminal and archiver defaulted to NULL */

--- a/src/core/legacy/fm-config.h
+++ b/src/core/legacy/fm-config.h
@@ -47,6 +47,7 @@ typedef struct _FmConfig            FmConfig;
 #define     FM_CONFIG_DEFAULT_SHOW_THUMBNAIL    TRUE
 #define     FM_CONFIG_DEFAULT_THUMBNAIL_LOCAL   TRUE
 #define     FM_CONFIG_DEFAULT_THUMBNAIL_MAX     2048
+#define     FM_CONFIG_DEFAULT_EXTERNAL_THUMBNAIL_MAX -1
 
 #define     FM_CONFIG_DEFAULT_FORCE_S_NOTIFY    TRUE
 #define     FM_CONFIG_DEFAULT_BACKUP_HIDDEN     TRUE
@@ -80,7 +81,8 @@ typedef struct _FmConfig            FmConfig;
  * @small_icon_size: size of small icons
  * @pane_icon_size: size of side pane icons
  * @thumbnail_size: size of thumbnail icons
- * @thumbnail_max: show thumbnails only for files not bigger than this, in KB or Kpix
+ * @thumbnail_max: internally create thumbnails only for images not bigger than this, in KB or Kpix
+ * @external_thumbnail_max: allow external thumbnail creation only for files not bigger than this, in KB or Kpix
  * @auto_selection_delay: (since 1.2.0) delay for autoselection in single-click mode, in ms
  * @drop_default_action: (since 1.2.0) default action on drop (see #FmDndDestDropAction)
  * @single_click: single click to open file
@@ -133,6 +135,7 @@ struct _FmConfig
     gint pane_icon_size;
     gint thumbnail_size;
     gint thumbnail_max;
+    gint external_thumbnail_max;
     gint auto_selection_delay;
     gint drop_default_action;
 

--- a/src/core/thumbnailjob.h
+++ b/src/core/thumbnailjob.h
@@ -35,6 +35,12 @@ public:
 
     static void setMaxThumbnailFileSize(int size);
 
+    static int maxExternalThumbnailFileSize() {
+        return maxExternalThumbnailFileSize_;
+    }
+
+    static void setMaxExternalThumbnailFileSize(int size);
+
     const std::vector<QImage>& results() const {
         return results_;
     }
@@ -71,6 +77,7 @@ private:
 
     static bool localFilesOnly_;
     static int maxThumbnailFileSize_;
+    static int maxExternalThumbnailFileSize_;
 };
 
 } // namespace Fm


### PR DESCRIPTION
Since we don't create external thumbnails and their corresponding apps are responsible for them, we shouldn't force the file size limit of the built-in thumbnailer on them.

By default, the external limit is -1 (= no limit), while the internal limit is 4 MiB.

WARNING: All libfm-qt based apps should be recompiled after this.

NOTE: A PR for pcmanfm-qt will follow this to add an option for external thumbnailers.

Closes https://github.com/lxqt/libfm-qt/issues/642