### PR TITLE
Added mount, unmount and eject actions to file context menu when possible

### DIFF
--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -13,6 +13,9 @@ const char defaultGFileInfoQueryAttribs[] = "standard::*,"
                                             "trash::deletion-date,"
                                             "id::filesystem,"
                                             "metadata::emblems,"
+                                            "mountable::can-mount,"
+                                            "mountable::can-unmount,"
+                                            "mountable::can-eject,"
                                             METADATA_TRUST;
 
 FileInfo::FileInfo() {
@@ -131,6 +134,21 @@ void FileInfo::setFromGFileInfo(const GObjectPtr<GFileInfo>& inf, const FilePath
 
     isShortcut_ = (type == G_FILE_TYPE_SHORTCUT);
     isMountable_ = (type == G_FILE_TYPE_MOUNTABLE);
+
+    canMount_ = canUnmount_ = canEject_ = false;
+    if(isMountable_) {
+        if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_MOUNTABLE_CAN_MOUNT)) {
+            canMount_ = g_file_info_get_attribute_boolean(inf.get(), G_FILE_ATTRIBUTE_MOUNTABLE_CAN_MOUNT);
+        }
+
+        if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_MOUNTABLE_CAN_UNMOUNT)) {
+            canUnmount_ = g_file_info_get_attribute_boolean(inf.get(), G_FILE_ATTRIBUTE_MOUNTABLE_CAN_UNMOUNT);
+        }
+
+        if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_MOUNTABLE_CAN_EJECT)) {
+            canEject_ = g_file_info_get_attribute_boolean(inf.get(), G_FILE_ATTRIBUTE_MOUNTABLE_CAN_EJECT);
+        }
+    }
 
     /* special handling for symlinks */
     if(g_file_info_get_is_symlink(inf.get())) {

--- a/src/core/fileinfo.h
+++ b/src/core/fileinfo.h
@@ -175,6 +175,19 @@ public:
         return dirPath_ ? dirPath_.isNative() : path().isNative();
     }
 
+    bool canMount() const {
+        return canMount_;
+    }
+
+    bool canUnmount() const {
+        return canUnmount_;
+    }
+
+    bool canEject() const {
+        return canEject_;
+    }
+
+
     mode_t mode() const {
         return mode_;
     }
@@ -260,6 +273,9 @@ private:
     bool isIconChangeable_ : 1; /* TRUE if icon can be changed */
     bool isHiddenChangeable_ : 1; /* TRUE if hidden can be changed */
     bool isReadOnly_ : 1; /* TRUE if host FS is R/O */
+    bool canMount_ : 1;  /* TRUE if can be mounted */
+    bool canUnmount_ : 1; /* TRUE if can be unmounted */
+    bool canEject_ : 1; /* TRUE if can be ejected */
 };
 
 

--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -41,6 +41,7 @@ FolderItemDelegate::FolderItemDelegate(QAbstractItemView* view, QObject* parent)
     QStyledItemDelegate(parent ? parent : view),
     symlinkIcon_(QIcon::fromTheme(QStringLiteral("emblem-symbolic-link"))),
     untrustedIcon_(QIcon::fromTheme(QStringLiteral("emblem-important"))),
+    mountedIcon_(QIcon::fromTheme(QStringLiteral("emblem-mounted"))),
     addIcon_(QIcon::fromTheme(QStringLiteral("list-add"))),
     removeIcon_(QIcon::fromTheme(QStringLiteral("list-remove"))),
     fileInfoRole_(Fm::FolderModel::FileInfoRole),
@@ -174,6 +175,11 @@ void FolderItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& op
             untrustedIcon_.paint(painter, iconRect.translated(0, option.decorationSize.height() / 2), Qt::AlignCenter, iconMode);
         }
 
+        if(file && file->canUnmount()) {
+            // emblem for mounted mountable files
+            mountedIcon_.paint(painter, iconRect.translated(option.decorationSize.width() / 2, 0), Qt::AlignCenter, iconMode);
+        }
+
         // draw other emblems if there's any
         if(!emblems.empty()) {
             // FIXME: we only support one emblem now
@@ -270,6 +276,9 @@ void FolderItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& op
         }
         if(untrusted) {
             untrustedIcon_.paint(painter, iconRect.translated(0, option.decorationSize.height() / 2), Qt::AlignCenter, iconMode);
+        }
+        if(file && file->canUnmount()) {
+            mountedIcon_.paint(painter, iconRect.translated(option.decorationSize.width() / 2, 0), Qt::AlignCenter, iconMode);
         }
         if(!emblems.empty()) {
             // FIXME: we only support one emblem now

--- a/src/folderitemdelegate.h
+++ b/src/folderitemdelegate.h
@@ -115,6 +115,7 @@ private:
 private:
     QIcon symlinkIcon_;
     QIcon untrustedIcon_;
+    QIcon mountedIcon_;
     QIcon addIcon_;
     QIcon removeIcon_;
     QSize iconSize_;

--- a/src/mountoperation.cpp
+++ b/src/mountoperation.cpp
@@ -146,6 +146,15 @@ void MountOperation::onEjectVolumeFinished(GVolume* volume, GAsyncResult* res, Q
     delete pThis;
 }
 
+void MountOperation::onEjectFileFinished(GFile* file, GAsyncResult* res, QPointer<MountOperation>* pThis) {
+    if(*pThis) {
+        GError* error = nullptr;
+        g_file_eject_mountable_with_operation_finish(file, res, &error);
+        (*pThis)->handleFinish(error);
+    }
+    delete pThis;
+}
+
 void MountOperation::onMountFileFinished(GFile* file, GAsyncResult* res, QPointer< MountOperation >* pThis) {
     if(*pThis) {
         GError* error = nullptr;
@@ -177,6 +186,15 @@ void MountOperation::onUnmountMountFinished(GMount* mount, GAsyncResult* res, QP
     if(*pThis) {
         GError* error = nullptr;
         g_mount_unmount_with_operation_finish(mount, res, &error);
+        (*pThis)->handleFinish(error);
+    }
+    delete pThis;
+}
+
+void MountOperation::onUnmountFileFinished(GFile* file, GAsyncResult* res, QPointer<MountOperation>* pThis) {
+    if(*pThis) {
+        GError* error = nullptr;
+        g_file_unmount_mountable_with_operation_finish(file, res, &error);
         (*pThis)->handleFinish(error);
     }
     delete pThis;

--- a/src/mountoperation.h
+++ b/src/mountoperation.h
@@ -91,9 +91,10 @@ public:
     }
 
     void eject(const Fm::FilePath& path) {
-        GMount* mnt = g_file_find_enclosing_mount(path.gfile().get(), nullptr, nullptr);
-        prepareUnmount(mnt);
-        g_object_unref(mnt);
+        if(GMount* mnt = g_file_find_enclosing_mount(path.gfile().get(), nullptr, nullptr)) {
+            prepareUnmount(mnt);
+            g_object_unref(mnt);
+        }
         g_file_eject_mountable_with_operation(path.gfile().get(), G_MOUNT_UNMOUNT_NONE, op, cancellable_, (GAsyncReadyCallback)onEjectFileFinished, new QPointer<MountOperation>(this));
     }
 

--- a/src/mountoperation.h
+++ b/src/mountoperation.h
@@ -74,6 +74,10 @@ public:
         g_object_unref(mount);
     }
 
+    void unmount(const Fm::FilePath& path) {
+        g_file_unmount_mountable_with_operation(path.gfile().get(), G_MOUNT_UNMOUNT_NONE, op, cancellable_, (GAsyncReadyCallback)onUnmountFileFinished, new QPointer<MountOperation>(this));
+    }
+
     void eject(GMount* mount) {
         prepareUnmount(mount);
         g_mount_eject_with_operation(mount, G_MOUNT_UNMOUNT_NONE, op, cancellable_, (GAsyncReadyCallback)onEjectMountFinished, new QPointer<MountOperation>(this));
@@ -84,6 +88,13 @@ public:
         prepareUnmount(mnt);
         g_object_unref(mnt);
         g_volume_eject_with_operation(volume, G_MOUNT_UNMOUNT_NONE, op, cancellable_, (GAsyncReadyCallback)onEjectVolumeFinished, new QPointer<MountOperation>(this));
+    }
+
+    void eject(const Fm::FilePath& path) {
+        GMount* mnt = g_file_find_enclosing_mount(path.gfile().get(), nullptr, nullptr);
+        prepareUnmount(mnt);
+        g_object_unref(mnt);
+        g_file_eject_mountable_with_operation(path.gfile().get(), G_MOUNT_UNMOUNT_NONE, op, cancellable_, (GAsyncReadyCallback)onEjectFileFinished, new QPointer<MountOperation>(this));
     }
 
     QWidget* parent() const {
@@ -141,8 +152,10 @@ private:
     static void onMountMountableFinished(GFile* file, GAsyncResult* res, QPointer<MountOperation>* pThis);
     static void onMountVolumeFinished(GVolume* volume, GAsyncResult* res, QPointer<MountOperation>* pThis);
     static void onUnmountMountFinished(GMount* mount, GAsyncResult* res, QPointer<MountOperation>* pThis);
+    static void onUnmountFileFinished(GFile* file, GAsyncResult* res, QPointer<MountOperation>* pThis);
     static void onEjectMountFinished(GMount* mount, GAsyncResult* res, QPointer<MountOperation>* pThis);
     static void onEjectVolumeFinished(GVolume* volume, GAsyncResult* res, QPointer<MountOperation>* pThis);
+    static void onEjectFileFinished(GFile* file, GAsyncResult* res, QPointer<MountOperation>* pThis);
 
     void handleFinish(GError* error);
 


### PR DESCRIPTION
Particularly, the items inside `computer:///` can have those actions in their context menus.

Also, added an emblem to the icons of mounted files.

Closes https://github.com/lxqt/libfm-qt/issues/658

WARNING: All libfm-qt based apps — and especially pcmanfm-qt — should be recompiled.