### PR TITLE
Workaround for a bug is GFileMonitor regarding symlinks

### DIFF
--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -12,6 +12,7 @@ const char defaultGFileInfoQueryAttribs[] = "standard::*,"
                                             "access::*,"
                                             "trash::deletion-date,"
                                             "id::filesystem,"
+                                            "id::file,"
                                             "metadata::emblems,"
                                             METADATA_TRUST;
 
@@ -258,6 +259,9 @@ _file_is_symlink:
 
     tmp = g_file_info_get_attribute_string(inf.get(), G_FILE_ATTRIBUTE_ID_FILESYSTEM);
     filesystemId_ = g_intern_string(tmp);
+
+    tmp = g_file_info_get_attribute_string(inf.get(), G_FILE_ATTRIBUTE_ID_FILE);
+    fileId_ = g_intern_string(tmp);
 
     mtime_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_TIME_MODIFIED);
     atime_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_TIME_ACCESS);

--- a/src/core/fileinfo.h
+++ b/src/core/fileinfo.h
@@ -81,6 +81,10 @@ public:
         return filesystemId_;
     }
 
+    const char* fileId() const {
+        return fileId_;
+    }
+
     const std::shared_ptr<const IconInfo>& icon() const {
         return icon_;
     }
@@ -231,6 +235,7 @@ private:
 
     mode_t mode_;
     const char* filesystemId_;
+    const char* fileId_;
     uid_t uid_;
     gid_t gid_;
     uint64_t size_;

--- a/src/core/folder.h
+++ b/src/core/folder.h
@@ -134,6 +134,8 @@ private:
 
 private Q_SLOTS:
 
+    void reallyReload();
+
     void processPendingChanges();
 
     void onDirListFinished();


### PR DESCRIPTION
If a single `GFileMonitor` is unreffed, those of open folders with the same (symlink) target will stop emitting signals and become useless. That's an old bug in GLib and this patch is a workaround for it by:

 1. Unreffing the old file monitor only after a new one is created when reloading a folder; and
 2. Finding and reloading all open folders that have the same target of the folder that is closed.

A new method is added to `Fm::FileInfo` to get the file identifier. By using a simple pointer comparison, it can be used to find files that have the same target.

Closes https://github.com/lxqt/pcmanfm-qt/issues/607

NOTE: All libfm-qt based apps should be recompiled.