### PR TITLE
Workaround for Qt bug that causes scroll jump in compact view

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -282,6 +282,19 @@ QModelIndex FolderViewListView::moveCursor(CursorAction cursorAction, Qt::Keyboa
     return QListView::moveCursor(cursorAction, modifiers);
 }
 
+void FolderViewListView::currentChanged(const QModelIndex &current, const QModelIndex &previous) {
+    QListView::currentChanged(current, previous);
+    if(viewMode() == QListView::ListMode && current.isValid()) {
+        // QListView has a bug that may reset the horizontal scrollbar
+        // in the list mode when the current item changes. This is a workaround.
+        QTimer::singleShot(0, this, [this] {
+            if(currentIndex().isValid()) {
+                scrollTo(currentIndex());
+            }
+        });
+    }
+}
+
 void FolderViewListView::activation(const QModelIndex& index) {
     if(activationAllowed_) {
         Q_EMIT activatedFiltered(index);

--- a/src/folderview_p.h
+++ b/src/folderview_p.h
@@ -70,6 +70,7 @@ Q_SIGNALS:
 
 protected:
   QModelIndex moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers) override;
+  void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
 
 public Q_SLOTS:
   void selectAll() override;


### PR DESCRIPTION
QListView may reset the horizontal scrollbar in the list mode when the current item changes. This is a workaround.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1360

NOTE: IMO, it's better to recompile libfm-qt based apps after applying this patch.