### PR TITLE
Prevent self-overwriting in file prompt dialog

### DIFF
--- a/src/fileoperationdialog.cpp
+++ b/src/fileoperationdialog.cpp
@@ -104,7 +104,10 @@ int FileOperationDialog::ask(QString /*question*/, char* const* /*options*/) {
 
 FileOperationJob::FileExistsAction FileOperationDialog::askRename(const FileInfo &src, const FileInfo &dest, FilePath &newDest) {
     FileOperationJob::FileExistsAction ret;
-    if(defaultOption == -1) { // default action is not set, ask the user
+    // ask user if default action is not set or a self-overwriting might happen
+    if(defaultOption == -1
+       || (defaultOption == RenameDialog::ActionOverwrite
+           && src.path() == dest.path())) {
         RenameDialog dlg(src, dest, this);
         dlg.exec();
         switch(dlg.action()) {

--- a/src/rename-dialog.ui
+++ b/src/rename-dialog.ui
@@ -58,7 +58,7 @@
       </widget>
      </item>
      <item row="1" column="0" colspan="2">
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="srcLabel">
        <property name="text">
         <string>with the following file?</string>
        </property>

--- a/src/renamedialog.cpp
+++ b/src/renamedialog.cpp
@@ -99,6 +99,15 @@ RenameDialog::RenameDialog(const FileInfo &src, const FileInfo &dest, QWidget* p
     connect(renameButton_, &QPushButton::clicked, this, &RenameDialog::onRenameClicked);
     renameButton_->setEnabled(false); // disabled by default
 
+    // do not allow self-overwriting; tell user to choose another name instead
+    if(path == src.path()) {
+        button->setEnabled(false);
+        ui->srcLabel->setVisible(false);
+        ui->srcIcon->setVisible(false);
+        ui->srcInfo->setVisible(false);
+        ui->label->setText(tr("<p><b>The file cannot overwrite itself.</b></p><p>Please select another name.</p>"));
+    }
+
     button = ui->buttonBox->button(QDialogButtonBox::Ignore);
     connect(button, &QPushButton::clicked, this, &RenameDialog::onIgnoreClicked);
 }
@@ -136,7 +145,11 @@ void RenameDialog::onFileNameChanged(QString newName) {
     renameButton_->setEnabled(hasNewName);
     renameButton_->setDefault(hasNewName);
 
-    // change default button to rename rather than overwrire
+    if(!ui->srcInfo->isVisible()) {
+        return; // this was a self-overwriting prompt
+    }
+
+    // change default button to rename rather than overwrite
     // if the user typed a new filename
     QPushButton* overwriteButton = static_cast<QPushButton*>(ui->buttonBox->button(QDialogButtonBox::Ok));
     overwriteButton->setEnabled(!hasNewName);


### PR DESCRIPTION
Ask the user to change the destination name instead of self-overwriting.

Closes https://github.com/lxqt/libfm-qt/issues/686