### PR TITLE
Added a signal for inline renaming

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -988,7 +988,9 @@ void FolderView::onClosingEditor(QWidget* editor, QAbstractItemDelegate::EndEdit
             if (window() == this) { // supposedly desktop, in case it uses this
                 parent = nullptr;
             }
-            changeFileName(info->path(), newName, parent);
+            if(changeFileName(info->path(), newName, parent)) {
+                Q_EMIT inlineRenamed(oldName, newName);
+            }
         }
     }
 }

--- a/src/folderview.h
+++ b/src/folderview.h
@@ -185,6 +185,8 @@ Q_SIGNALS:
     void columnResizedByUser();
     void columnHiddenByUser();
 
+    void inlineRenamed(const QString& oldName, const QString& newName);
+
 private:
 
     QAbstractItemView* view;


### PR DESCRIPTION
It can be used especially by Desktop for knowing how a file name is changed by inline renaming and keeping its custom positions.

NOTE: libfm-qt based apps need recompilation.