### PR TITLE
Fixed device usage of file properties dialog is rare cases

### DIFF
--- a/src/filepropsdialog.h
+++ b/src/filepropsdialog.h
@@ -38,7 +38,7 @@ class LIBFM_QT_API FilePropsDialog : public QDialog {
     Q_OBJECT
 
 public:
-    explicit FilePropsDialog(Fm::FileInfoList files, QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+    explicit FilePropsDialog(Fm::FileInfoList files, QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags(), bool parentDeviceUsage = true);
     ~FilePropsDialog() override;
 
     void accept() override;
@@ -46,7 +46,11 @@ public:
     static FilePropsDialog* showForFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent = nullptr) {
         Fm::FileInfoList files;
         files.push_back(std::move(file));
-        FilePropsDialog* dlg = showForFiles(files, parent);
+        // NOTE: showForFile() is usually called to show the properties of the current folder,
+        // whose device usage may be different from that of its parent folder (as with "/tmp").
+        // But that will be checked later, in FilePropsDialog::initGeneralPage().
+        FilePropsDialog* dlg = new FilePropsDialog(std::move(files), parent, Qt::WindowFlags(), false);
+        dlg->show();
         return dlg;
     }
 
@@ -57,7 +61,7 @@ public:
     }
 
 private:
-    void initGeneralPage();
+    void initGeneralPage(bool parentDeviceUsage);
     void initApplications();
     void initPermissionsPage();
     void initOwner();


### PR DESCRIPTION
The device usage of a folder (like `/tmp`) may be different from that of its parent folder. In such cases, the file properties dialog showed different device usages on right clicking an empty space of the folder, depending on whether the parent folder was also opened (in another tab) or not.

This patch is rather a compromise between a total fix, which would require changes to the codes of `libfm-qt`-based apps, and the current situation. It practically fixes the issue without needing code changes to those apps.

WARNING: All `libfm-qt`-based apps should be recompiled; otherwise they might not run after applying this patch (and will give "symbol lookup error").

Fixes https://github.com/lxqt/libfm-qt/issues/696