### PR TITLE
Fixed a memory leak in side-pane's volume items

### DIFF
--- a/src/placesmodelitem.cpp
+++ b/src/placesmodelitem.cpp
@@ -98,6 +98,10 @@ PlacesModelVolumeItem::PlacesModelVolumeItem(GVolume* volume):
     setEditable(false);
 }
 
+PlacesModelVolumeItem::~PlacesModelVolumeItem() {
+    g_object_unref(volume_);
+}
+
 void PlacesModelVolumeItem::update() {
     // set title
     char* volumeName = g_volume_get_name(volume_);
@@ -149,9 +153,13 @@ bool PlacesModelVolumeItem::isMounted() {
 
 PlacesModelMountItem::PlacesModelMountItem(GMount* mount):
     PlacesModelItem(),
-    mount_(reinterpret_cast<GMount*>(mount)) {
+    mount_(reinterpret_cast<GMount*>(g_object_ref(mount))) {
     update();
     setEditable(false);
+}
+
+PlacesModelMountItem::~PlacesModelMountItem() {
+    g_object_unref(mount_);
 }
 
 void PlacesModelMountItem::update() {

--- a/src/placesmodelitem.h
+++ b/src/placesmodelitem.h
@@ -86,6 +86,8 @@ private:
 class LIBFM_QT_API PlacesModelVolumeItem : public PlacesModelItem {
 public:
     PlacesModelVolumeItem(GVolume* volume);
+    ~PlacesModelVolumeItem() override;
+
     bool isMounted();
     bool canEject() {
         return g_volume_can_eject(volume_);
@@ -104,6 +106,8 @@ private:
 class LIBFM_QT_API PlacesModelMountItem : public PlacesModelItem {
 public:
     PlacesModelMountItem(GMount* mount);
+    ~PlacesModelMountItem() override;
+
     int type() const override {
         return Mount;
     }


### PR DESCRIPTION
Also applied the same logic to mount items.

Recompilation of `libfm-qt`-based apps is recommended.