### PR TITLE
Avoided a freeze on mounting encrypted volumes

### DIFF
--- a/src/mountoperation.cpp
+++ b/src/mountoperation.cpp
@@ -24,7 +24,6 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QEventLoop>
-#include "mountoperationpassworddialog_p.h"
 #include "mountoperationquestiondialog_p.h"
 #include "ui_mount-operation-password.h"
 #include "core/gioptrs.h"
@@ -39,6 +38,10 @@ MountOperation::MountOperation(bool interactive, QWidget* parent):
     interactive_(interactive),
     eventLoop(nullptr),
     autoDestroy_(true) {
+
+    tmpOp_ = nullptr;
+    volume_ = nullptr;
+    dlg_ = nullptr;
 
     g_signal_connect(op, "ask-password", G_CALLBACK(onAskPassword), this);
     g_signal_connect(op, "ask-question", G_CALLBACK(onAskQuestion), this);
@@ -82,6 +85,16 @@ MountOperation::~MountOperation() {
 #endif
         g_object_unref(op);
     }
+
+    if(volume_) {
+        g_object_unref(volume_);
+    }
+    if(tmpOp_) {
+        g_object_unref(tmpOp_);
+    }
+    if(dlg_) { // impossible
+        delete dlg_;
+    }
     // qDebug("MountOperation deleted");
 }
 
@@ -100,12 +113,60 @@ void MountOperation::onAbort(GMountOperation* /*_op*/, MountOperation* /*pThis*/
 }
 
 void MountOperation::onAskPassword(GMountOperation* /*_op*/, gchar* message, gchar* default_user, gchar* default_domain, GAskPasswordFlags flags, MountOperation* pThis) {
-    qDebug("ask password");
-    MountOperationPasswordDialog dlg(pThis, flags);
-    dlg.setMessage(QString::fromUtf8(message));
-    dlg.setDefaultUser(QString::fromUtf8(default_user));
-    dlg.setDefaultDomain(QString::fromUtf8(default_domain));
-    dlg.exec();
+    //qDebug("ask password");
+    if(!pThis->volume_) {
+        // The mount is NOT done by g_volume_mount();
+        // it is safe to show the password dialog (see below).
+        MountOperationPasswordDialog dlg(pThis, flags);
+        dlg.setMessage(QString::fromUtf8(message));
+        dlg.setDefaultUser(QString::fromUtf8(default_user));
+        dlg.setDefaultDomain(QString::fromUtf8(default_domain));
+        dlg.exec();
+        return;
+    }
+
+    /*
+      NOTE: With g_volume_mount(), having a local event loop here (by showing a dialog) will
+      result in a total freeze if a volume is added/removed while the loop is running. This
+      may be a bug in GVFS or in how Qt handles GLib event loops (I, @tsujan, am not sure).
+
+      As a workaround, only the needed info is gathered here and the password dialog is
+      shown in handleFinish(). After the dialog is accepted, the volume is mounted again and
+      the info provided by the dialog is used to set the password and other mount properties
+      when this function is called again.
+    */
+    if(!pThis->tmpOp_) { // gather the needed info
+        pThis->tmpOp_ = g_mount_operation_new(); // used to save mount info later
+        pThis->dlg_ = new MountOperationPasswordDialog(pThis, flags);
+        pThis->dlg_->setAttribute (Qt::WA_DeleteOnClose);
+        pThis->dlg_->setMessage(QString::fromUtf8(message));
+        pThis->dlg_->setDefaultUser(QString::fromUtf8(default_user));
+        pThis->dlg_->setDefaultDomain(QString::fromUtf8(default_domain));
+    }
+    else { // set the password and other mount properties
+        const char* userName = g_mount_operation_get_username(pThis->tmpOp_);
+        const char* domain = g_mount_operation_get_domain(pThis->tmpOp_);
+        const char* password = g_mount_operation_get_password(pThis->tmpOp_);
+
+        if(userName) {
+            g_mount_operation_set_username(pThis->op, userName);
+        }
+        if(domain) {
+            g_mount_operation_set_password(pThis->op, domain);
+        }
+        if(password) {
+            g_mount_operation_set_password(pThis->op, password);
+            g_mount_operation_set_password_save(pThis->op,
+                                                g_mount_operation_get_password_save(pThis->tmpOp_));
+        }
+        g_mount_operation_set_anonymous(pThis->op,
+                                        g_mount_operation_get_anonymous(pThis->tmpOp_));
+
+        g_object_unref(pThis->tmpOp_);
+        pThis->tmpOp_ = nullptr;
+
+        g_mount_operation_reply(pThis->op, G_MOUNT_OPERATION_HANDLED);
+    }
 }
 
 void MountOperation::onAskQuestion(GMountOperation* /*_op*/, gchar* message, GStrv choices, MountOperation* pThis) {
@@ -201,6 +262,17 @@ void MountOperation::onUnmountFileFinished(GFile* file, GAsyncResult* res, QPoin
 }
 
 void MountOperation::handleFinish(GError* error) {
+    if(volume_ && tmpOp_ && dlg_) { // see onAskPassword()
+        if(error) {
+            g_error_free(error);
+            error = nullptr;
+        }
+        if(dlg_->exec()) {
+            mount(volume_);
+            return;
+        }
+    }
+
     qDebug("operation finished: %p", static_cast<void *>(error));
     if(error) {
         bool showError = interactive_;


### PR DESCRIPTION
For some reason unknown to me (GVFS or Qt bug?), having any local event loop in response to `GMountOperation`'s signal "ask-password" will cause a total app freeze if the mounting is done by `g_volume_mount()` *and* a volume is added/removed during the loop. Such a loop is needed for entering the password. The freeze also happens on auto-mounting a drive with both encrypted and non-encrypted partitions, for the same reason.

This patch works around the problem by *not* showing the password dialog in response to "ask-password" when `g_volume_mount()` is used. Instead, it first tries to mount the volume without a password. In case a password is needed, (a) it shows the password dialog only after the mount failure but without showing an error message, (b) saves the results of the user's actions and (c) mounts the volume again by using those results.

To the user, everything should seem like before but without the possibility of a freeze; he doesn't see the stages a, b and c.

NOTE: All `libfm-qt`-based apps should be recompiled.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1414