### PR TITLE
Support adding/removing emblems with File Properties dialog

### DIFF
--- a/src/core/fileinfo.h
+++ b/src/core/fileinfo.h
@@ -230,6 +230,8 @@ public:
         return emblems_;
     }
 
+    void setEmblem(const QString& emblmeName, bool setGFileEmblem = true) const;
+
     bool isTrustable() const;
 
     void setTrustable(bool trust) const;
@@ -263,7 +265,7 @@ private:
 
     std::shared_ptr<const MimeType> mimeType_;
     std::shared_ptr<const IconInfo> icon_;
-    std::forward_list<std::shared_ptr<const IconInfo>> emblems_;
+    mutable std::forward_list<std::shared_ptr<const IconInfo>> emblems_;
 
     std::string target_; /* target of shortcut or mountable. */
 

--- a/src/file-props.ui
+++ b/src/file-props.ui
@@ -325,6 +325,49 @@
         </widget>
        </item>
        <item row="12" column="0">
+        <widget class="QLabel" name="label_14">
+         <property name="text">
+          <string>Emblem:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="spacing">
+          <number>10</number>
+         </property>
+         <item>
+          <widget class="QToolButton" name="emblemButton">
+           <property name="toolTip">
+            <string>Choose emblem</string>
+           </property>
+           <property name="text">
+            <string notr="true">...</string>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonIconOnly</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="clearEmblemButton">
+           <property name="text">
+            <string>Clear emblem</string>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonTextOnly</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="13" column="0">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -340,7 +383,7 @@
          </property>
         </spacer>
        </item>
-       <item row="13" column="0" colspan="2">
+       <item row="14" column="0" colspan="2">
         <layout class="QGridLayout" name="gridLayout_3">
          <property name="horizontalSpacing">
           <number>10</number>

--- a/src/filepropsdialog.h
+++ b/src/filepropsdialog.h
@@ -66,6 +66,8 @@ private Q_SLOTS:
     void onDeepCountJobFinished();
     void onFileSizeTimerTimeout();
     void onIconButtonclicked();
+    void onEmblemButtonclicked();
+    void onClearEmblemButtonclicked();
 
 private:
     Ui::FilePropsDialog* ui;


### PR DESCRIPTION
When the emblem button is clicked, a file dialog is opened inside the active icon theme. The "emblems" folder will be prioritized if it's a top-level directory but any icon can be selected from the theme.

Also, a button is added for clearing emblems.

*WARNING:* `libfm-qt`-based apps should be recompiled.

Closes https://github.com/lxqt/libfm-qt/issues/700