### PR TITLE
Fixed Cyrillic case-insensitive regex_search

### DIFF
--- a/src/core/vfs/vfs-search.c
+++ b/src/core/vfs/vfs-search.c
@@ -1,6 +1,6 @@
 /*
  *      fm-vfs-search.c
- * 
+ *
  *      Copyright 2012 Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
  *      Copyright 2010 Shae Smittle <starfall87@gmail.com>
  *
@@ -66,8 +66,10 @@ struct _FmVfsSearchEnumerator
     GSList* target_folders; /* GFile */
     char** name_patterns;
     GRegex* name_regex;
+    GRegex* name_regex_utf8; /* to be made without G_REGEX_RAW */
     char* content_pattern;
     GRegex* content_regex;
+    GRegex* content_regex_utf8; /* to be made without G_REGEX_RAW */
     char** mime_types;
     guint64 min_mtime;
     guint64 max_mtime;
@@ -193,6 +195,12 @@ static void _fm_vfs_search_enumerator_dispose(GObject *object)
         priv->name_regex = NULL;
     }
 
+    if(priv->name_regex_utf8)
+    {
+        g_regex_unref(priv->name_regex_utf8);
+        priv->name_regex_utf8 = NULL;
+    }
+
     if(priv->content_pattern)
     {
         g_free(priv->content_pattern);
@@ -203,6 +211,12 @@ static void _fm_vfs_search_enumerator_dispose(GObject *object)
     {
         g_regex_unref(priv->content_regex);
         priv->content_regex = NULL;
+    }
+
+    if(priv->content_regex_utf8)
+    {
+        g_regex_unref(priv->content_regex_utf8);
+        priv->content_regex_utf8 = NULL;
     }
 
     if(priv->mime_types)
@@ -354,7 +368,7 @@ static void fm_vfs_search_enumerator_class_init(FmVfsSearchEnumeratorClass *klas
 
   enumerator_class->next_file = _fm_vfs_search_enumerator_next_file;
   enumerator_class->close_fn = _fm_vfs_search_enumerator_close;
-  
+
 }
 
 static void fm_vfs_search_enumerator_init(FmVfsSearchEnumerator *enumerator)
@@ -408,9 +422,9 @@ static time_t parse_date_str(const char* str)
  * parse_search_uri
  * @job
  * @uri: a search uri
- * 
+ *
  * Format of a search URI is similar to that of an http URI:
- * 
+ *
  * search://<folder1>,<folder2>,<folder...>?<parameter1=value1>&<parameter2=value2>&...
  * The optional parameter key/value pairs are:
  * show_hidden=<0 or 1>: whether to search for hidden files
@@ -426,15 +440,15 @@ static time_t parse_date_str(const char* str)
  * max_size=<bytes>
  * min_mtime=YYYY-MM-DD
  * max_mtime=YYYY-MM-DD
- * 
+ *
  * An example to search all *.desktop files in /usr/share and /usr/local/share
  * can be written like this:
- * 
+ *
  * search:///usr/share,/usr/local/share?recursive=1&show_hidden=0&name=*.desktop&name_ci=0
- * 
+ *
  * If the folder paths and parameters contain invalid characters for a
  * URI, they should be escaped.
- * 
+ *
  */
 static void parse_search_uri(FmVfsSearchEnumerator* priv, const char* uri_str)
 {
@@ -591,6 +605,10 @@ static void parse_search_uri(FmVfsSearchEnumerator* priv, const char* uri_str)
                 if(priv->name_case_insensitive)
                     flags |= G_REGEX_CASELESS;
                 priv->name_regex = g_regex_new(name_regex, flags, 0, NULL);
+                priv->name_regex_utf8 = g_regex_new(name_regex,
+                                                    priv->name_case_insensitive ? G_REGEX_CASELESS
+                                                                                : 0,
+                                                    0, NULL);
                 g_free(name_regex);
             }
 
@@ -600,6 +618,10 @@ static void parse_search_uri(FmVfsSearchEnumerator* priv, const char* uri_str)
                 if(priv->content_case_insensitive)
                     flags |= G_REGEX_CASELESS;
                 priv->content_regex = g_regex_new(content_regex, flags, 0, NULL);
+                priv->content_regex_utf8 = g_regex_new(content_regex,
+                                                       priv->content_case_insensitive ? G_REGEX_CASELESS
+                                                                                      : 0,
+                                                       0, NULL);
                 g_free(content_regex);
             }
 
@@ -645,7 +667,10 @@ static gboolean fm_search_job_match_filename(FmVfsSearchEnumerator* priv, GFileI
     if(priv->name_regex)
     {
         const char* name = g_file_info_get_name(info);
-        ret = g_regex_match(priv->name_regex, name, 0, NULL);
+        if(g_utf8_validate(name, -1, NULL))
+            ret = g_regex_match(priv->name_regex_utf8, name, 0, NULL);
+        else
+            ret = g_regex_match(priv->name_regex, name, 0, NULL);
     }
     else if(priv->name_patterns)
     {
@@ -686,7 +711,10 @@ static gboolean fm_search_job_match_content_line_based(FmVfsSearchEnumerator* pr
         if(priv->content_regex)
         {
             /* match using regexp */
-            ret = g_regex_match(priv->content_regex, line, 0, NULL);
+            if(g_utf8_validate(line, -1, NULL))
+                ret = g_regex_match(priv->content_regex_utf8, line, 0, NULL);
+            else
+                ret = g_regex_match(priv->content_regex, line, 0, NULL);
         }
         else if(priv->content_pattern && priv->content_case_insensitive)
         {
@@ -727,7 +755,7 @@ static gboolean fm_search_job_match_content_exact(FmVfsSearchEnumerator* priv,
     gssize size;
 
     /* Ensure that the allocated buffer is longer than the string being
-     * searched for. Otherwise it's not possible for the buffer to 
+     * searched for. Otherwise it's not possible for the buffer to
      * contain a string fully matching the pattern. */
     int pattern_len = strlen(priv->content_pattern);
     int buf_size = pattern_len > 4095 ? pattern_len : 4095;
@@ -752,7 +780,7 @@ static gboolean fm_search_job_match_content_exact(FmVfsSearchEnumerator* priv,
         }
         else if(size == bytes_to_read) /* if size < bytes_to_read, we're at EOF and there are no further data. */
         {
-            /* Preserve the last <pattern_len-1> bytes and move them to 
+            /* Preserve the last <pattern_len-1> bytes and move them to
              * the beginning of the buffer.
              * Append further data after this chunk of data at next read. */
             int preserve_len = pattern_len - 1;


### PR DESCRIPTION
Case-insensitive regex search in Cyrillic scripts is possible only when they're in UTF-8. But the code treated UTF-8 like non-UTF-8 by using the flag `G_REGEX_RAW` everywhere.

You could use the strings "ягода" and "ЯГОДА" to test the patch.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1358