### PR TITLE
handle floating file dialogs

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -21,9 +21,8 @@
 
 namespace Fm {
 
-
 FileDialog::FileDialog(QWidget* parent, FilePath path) :
-    QDialog(parent),
+    QDialog(Fm::parentWindow(parent, this)),
     ui{new Ui::FileDialog()},
     folderModel_{nullptr},
     proxyModel_{nullptr},
@@ -246,6 +245,7 @@ FileDialog::FileDialog(QWidget* parent, FilePath path) :
 }
 
 FileDialog::~FileDialog() {
+    removeFloatingWindow(this);
     freeFolder();
     delete proxyModel_;
     if(folderModel_) {

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -37,6 +37,32 @@
 
 namespace Fm {
 
+QList<QWidget*> floatingWindows_;
+
+const QList<QWidget*>& floatingWindows() {
+    return floatingWindows_;
+}
+
+void closeFloatingWindows() {
+    while (floatingWindows_.size() > 0) {
+        auto w = floatingWindows_.takeFirst();
+        delete w;
+    }
+}
+
+void removeFloatingWindow(QWidget* w) {
+    floatingWindows_.removeAll(w);
+}
+
+QWidget* parentWindow(QWidget* parent, QWidget* w) {
+    if (parent->testAttribute(Qt::WA_X11NetWmWindowTypeDesktop)) {
+        floatingWindows_ << w;
+        return nullptr;
+    }
+
+    return parent;
+}
+
 Fm::FilePathList pathListFromUriList(const char* uriList) {
     Fm::FilePathList pathList;
     char** uris = g_strsplit_set(uriList, "\r\n", -1);

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -34,8 +34,14 @@
 #include "core/templates.h"
 
 class QDialog;
+class QWidget;
 
 namespace Fm {
+
+LIBFM_QT_API const QList<QWidget*>& floatingWindows();
+LIBFM_QT_API void closeFloatingWindows();
+LIBFM_QT_API void removeFloatingWindow(QWidget* w);
+LIBFM_QT_API QWidget* parentWindow(QWidget* parent, QWidget* w);
 
 LIBFM_QT_API Fm::FilePathList pathListFromUriList(const char* uriList);
 


### PR DESCRIPTION
This provides a concept for a window manager agnostic integration for PCManFM-Qt.

:bulb: Note:
Window pointers can leak if not used in conjunction with [pcmanfm-qt#1440](https://github.com/lxqt/pcmanfm-qt/pull/1440)

@stefonarch Could you test this on xfwm4?