### PR TITLE
Smooth scrolling in compact and detailed list modes

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1637,10 +1637,6 @@ bool FolderView::eventFilter(QObject* watched, QEvent* event) {
             }
             break;
         case QEvent::Wheel: {
-            if(!view) {
-                break;
-            }
-
             bool horizontalListView(false);
 
             // don't let the view scroll during an inline renaming


### PR DESCRIPTION
Qt's jumpy scrolls with mouse wheel from inside the view can get annoying in those modes. The patch extends the smooth scrolling to them. Moreover, the code is made a little simpler and tidier this way.