### PR TITLE
Remember hidden columns of LXQt file dialog

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -435,6 +435,14 @@ void FileDialog::setThumbnailIconSize(int size) {
     }
 }
 
+QList<int> FileDialog::getHiddenColumns() const {
+    return ui->folderView->getHiddenColumns();
+}
+
+void FileDialog::setHiddenColumns(const QList<int> &columns) {
+    ui->folderView->setHiddenColumns(columns);
+}
+
 // This should always be used instead of getting text directly from the entry.
 QStringList FileDialog::parseNames() const {
     // parse the file names from the text entry

--- a/src/filedialog.h
+++ b/src/filedialog.h
@@ -160,6 +160,9 @@ public:
     int thumbnailIconSize() const;
     void setThumbnailIconSize(int size);
 
+    QList<int> getHiddenColumns() const;
+    void setHiddenColumns(const QList<int> &columns);
+
 protected:
     bool eventFilter(QObject* watched, QEvent* event) override;
 

--- a/src/filedialoghelper.cpp
+++ b/src/filedialoghelper.cpp
@@ -319,6 +319,13 @@ void FileDialogHelper::loadSettings() {
     dlg_->setBigIconSize(settings.value(QStringLiteral("BigIconSize"), 48).toInt());
     dlg_->setSmallIconSize(settings.value(QStringLiteral("SmallIconSize"), 24).toInt());
     dlg_->setThumbnailIconSize(settings.value(QStringLiteral("ThumbnailIconSize"), 128).toInt());
+
+    const QList<QVariant> hiddenColumns = settings.value(QStringLiteral("HiddenColumns")).toList();
+    QList<int> l;
+    for(auto width : hiddenColumns) {
+        l << width.toInt();
+    }
+    dlg_->setHiddenColumns(l);
     settings.endGroup();
 
     settings.beginGroup(QStringLiteral("Places"));
@@ -392,6 +399,16 @@ void FileDialogHelper::saveSettings() {
     size = dlg_->thumbnailIconSize();
     if(settings.value(QStringLiteral("ThumbnailIconSize")).toInt() != size) {
         settings.setValue(QStringLiteral("ThumbnailIconSize"), size);
+    }
+
+    const QList<int> columns = dlg_->getHiddenColumns();
+    QList<QVariant> hiddenColumns;
+    for(auto column : columns) {
+        hiddenColumns << QVariant(column);
+    }
+    std::sort(hiddenColumns.begin(), hiddenColumns.end());
+    if(settings.value(QStringLiteral("HiddenColumns")).toList() != hiddenColumns) {
+        settings.setValue(QStringLiteral("HiddenColumns"), hiddenColumns);
     }
     settings.endGroup();
 


### PR DESCRIPTION
The user may not need all columns of the detailed list mode.

WARNING: If you don't recompile apps that are based on `libfm-qt`, you might encounter paranormal events.