### PR TITLE
Don't show "Select All" and "Invert Selection" if they're impossible

### DIFF
--- a/src/foldermenu.cpp
+++ b/src/foldermenu.cpp
@@ -71,15 +71,23 @@ FolderMenu::FolderMenu(FolderView* view, QWidget* parent):
         separator2_ = addSeparator();
     }
 
-    selectAllAction_ = new QAction(tr("Select &All"), this);
-    addAction(selectAllAction_);
-    connect(selectAllAction_, &QAction::triggered, this, &FolderMenu::onSelectAllActionTriggered);
+    auto selMode = view_->childView()->selectionMode();
+    if(selMode == QAbstractItemView::SingleSelection || selMode == QAbstractItemView::NoSelection) {
+        selectAllAction_ = nullptr;
+        invertSelectionAction_ = nullptr;
+        separator3_ = nullptr;
+    }
+    else {
+        selectAllAction_ = new QAction(tr("Select &All"), this);
+        addAction(selectAllAction_);
+        connect(selectAllAction_, &QAction::triggered, this, &FolderMenu::onSelectAllActionTriggered);
 
-    invertSelectionAction_ = new QAction(tr("Invert Selection"), this);
-    addAction(invertSelectionAction_);
-    connect(invertSelectionAction_, &QAction::triggered, this, &FolderMenu::onInvertSelectionActionTriggered);
+        invertSelectionAction_ = new QAction(tr("Invert Selection"), this);
+        addAction(invertSelectionAction_);
+        connect(invertSelectionAction_, &QAction::triggered, this, &FolderMenu::onInvertSelectionActionTriggered);
 
-    separator3_ = addSeparator();
+        separator3_ = addSeparator();
+    }
 
     sortAction_ = new QAction(tr("Sorting"), this);
     addAction(sortAction_);

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1491,8 +1491,8 @@ void FolderView::invertSelection() {
         const QItemSelection _all{model_->index(0, 0), model_->index(model_->rowCount() - 1, 0)};
         const QItemSelection _old{selModel->selection()};
 
-        selModel->select(_all, QItemSelectionModel::Select);
-        selModel->select(_old, QItemSelectionModel::Deselect);
+        selModel->select(_all, flags | QItemSelectionModel::Select);
+        selModel->select(_old, flags | QItemSelectionModel::Deselect);
     }
 }
 


### PR DESCRIPTION
They're impossible with single-selection mode (as in lximage-qt thumbnails bar or some file dialogs) and also with no-selection mode.

Also fixed a problem with "Invert Selection" in detailed list mode (the selection flag was forgotten).

Closes https://github.com/lxqt/lximage-qt/issues/466