### PR TITLE
Show folder context menu with Menu key and no selection

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1925,7 +1925,7 @@ void FolderView::onFileClicked(int type, const std::shared_ptr<const Fm::FileInf
                 menu = fileMenu;
             }
         }
-        else if (folderInfo()) {
+        if (!menu && folderInfo()) {
             Fm::FolderMenu* folderMenu = new Fm::FolderMenu(this);
             prepareFolderMenu(folderMenu);
             menu = folderMenu;


### PR DESCRIPTION
Previously, only the context menu of selected file(s) was shown by pressing Menu key.

Fixes https://github.com/lxqt/libfm-qt/issues/735