### PR TITLE
Added option for smooth scrolling to LXQt file dialog

### DIFF
--- a/src/filedialog.h
+++ b/src/filedialog.h
@@ -151,6 +151,11 @@ public:
     }
     void setNoItemTooltip(bool noItemTooltip);
 
+    bool scrollPerPixel() const {
+        return scrollPerPixel_;
+    }
+    void setScrollPerPixel(bool perPixel);
+
     int bigIconSize() const;
     void setBigIconSize(int size);
 
@@ -253,6 +258,7 @@ private:
     QMetaObject::Connection lambdaConnection_; // needed for disconnecting Fm::Folder signal from lambda:
     QSet<QString> hiddenPlaces_;
     bool noItemTooltip_;
+    bool scrollPerPixel_;
 };
 
 

--- a/src/filedialoghelper.cpp
+++ b/src/filedialoghelper.cpp
@@ -315,6 +315,7 @@ void FileDialogHelper::loadSettings() {
 
     dlg_->setShowThumbnails(settings.value(QStringLiteral("ShowThumbnails"), true).toBool());
     dlg_->setNoItemTooltip(settings.value(QStringLiteral("NoItemTooltip"), false).toBool());
+    dlg_->setScrollPerPixel(settings.value(QStringLiteral("ScrollPerPixel"), true).toBool());
 
     dlg_->setBigIconSize(settings.value(QStringLiteral("BigIconSize"), 48).toInt());
     dlg_->setSmallIconSize(settings.value(QStringLiteral("SmallIconSize"), 24).toInt());
@@ -386,6 +387,10 @@ void FileDialogHelper::saveSettings() {
     bool noItemTooltip = dlg_->noItemTooltip();
     if(settings.value(QStringLiteral("NoItemTooltip")).toBool() != noItemTooltip) {
         settings.setValue(QStringLiteral("NoItemTooltip"), noItemTooltip);
+    }
+    bool scrollPerPixel = dlg_->scrollPerPixel();
+    if(settings.value(QStringLiteral("ScrollPerPixel")).toBool() != scrollPerPixel) {
+        settings.setValue(QStringLiteral("ScrollPerPixel"), scrollPerPixel);
     }
 
     int size = dlg_->bigIconSize();

--- a/src/folderview.h
+++ b/src/folderview.h
@@ -135,6 +135,11 @@ public:
     }
     void setHiddenColumns(const QList<int> &columns);
 
+    bool scrollPerPixel() const {
+        return scrollPerPixel_;
+    }
+    void setScrollPerPixel(bool perPixel);
+
 protected:
     bool event(QEvent* event) override;
     void contextMenuEvent(QContextMenuEvent* event) override;
@@ -201,6 +206,7 @@ private:
     // the cell margins in the icon and thumbnail modes
     QSize itemDelegateMargins_;
     bool shadowHidden_;
+    bool scrollPerPixel_;
     bool ctrlRightClick_; // show folder context menu with Ctrl + right click
 
     // smooth scrolling:


### PR DESCRIPTION
It appears only with list and compact modes. By default, smooth scrolling is enabled.

The reason behind this option is that Qt may slow down item sorting when the number of items is huge and scrolling is done per pixel in list or compact mode. As a workaround, the user can disable per-pixel scrolling by disabling smooth scrolling.

Closes https://github.com/lxqt/libfm-qt/issues/739

WARNING: All libfm-qt based apps should be recompiled.