### PR TITLE
A fix to smooth scrolling in compact mode

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1121,11 +1121,11 @@ void FolderView::setViewMode(ViewMode _mode) {
         }
         else {
             listView = new FolderViewListView(this);
-            if(scrollPerPixel_ && mode == CompactMode) {
-                listView->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
-            }
             connect(listView, &FolderViewListView::activatedFiltered, this, &FolderView::onItemActivated);
             view = listView;
+        }
+        if(scrollPerPixel_ && mode == CompactMode) {
+            listView->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
         }
         setFocusProxy(listView);
 


### PR DESCRIPTION
Due to a copy-paste typo in the code, if the view was changed from icon to compact mode, smooth scrolling wouldn't work in the latter.