### PR TITLE
Prepare libfm-qt for implementing "Recent Files"

### DIFF
--- a/src/filelauncher.cpp
+++ b/src/filelauncher.cpp
@@ -41,13 +41,28 @@ FileLauncher::~FileLauncher() {
 bool FileLauncher::launchFiles(QWidget* parent, const FileInfoList &file_infos) {
     GObjectPtr<FmAppLaunchContext> context{fm_app_launch_context_new_for_widget(parent), false};
     bool ret = BasicFileLauncher::launchFiles(file_infos, G_APP_LAUNCH_CONTEXT(context.get()));
+    launchedFiles(file_infos);
     return ret;
 }
 
 bool FileLauncher::launchPaths(QWidget* parent, const FilePathList& paths) {
     GObjectPtr<FmAppLaunchContext> context{fm_app_launch_context_new_for_widget(parent), false};
     bool ret = BasicFileLauncher::launchPaths(paths, G_APP_LAUNCH_CONTEXT(context.get()));
+    launchedPaths(paths);
     return ret;
+}
+
+bool FileLauncher::launchWithApp(QWidget* parent, GAppInfo* app, const FilePathList& paths) {
+    GObjectPtr<FmAppLaunchContext> context{fm_app_launch_context_new_for_widget(parent), false};
+    bool ret = BasicFileLauncher::launchWithApp(app, paths, G_APP_LAUNCH_CONTEXT(context.get()));
+    launchedPaths(paths);
+    return ret;
+}
+
+void FileLauncher::launchedFiles(const FileInfoList& /*files*/) const {
+}
+
+void FileLauncher::launchedPaths(const FilePathList& /*paths*/) const {
 }
 
 int FileLauncher::ask(const char* /*msg*/, char* const* /*btn_labels*/, int /*default_btn*/) {

--- a/src/filelauncher.h
+++ b/src/filelauncher.h
@@ -37,6 +37,8 @@ public:
 
     bool launchPaths(QWidget* parent, const FilePathList &paths);
 
+    bool launchWithApp(QWidget* parent, GAppInfo* app, const FilePathList& paths);
+
 protected:
 
     GAppInfoPtr chooseApp(const FileInfoList& fileInfos, const char* mimeType, GErrorPtr& err) override;
@@ -48,6 +50,9 @@ protected:
     ExecAction askExecFile(const FileInfoPtr& file) override;
 
     int ask(const char* msg, char* const* btn_labels, int default_btn) override;
+
+    virtual void launchedFiles(const FileInfoList& files) const;
+    virtual void launchedPaths(const FilePathList& paths) const;
 };
 
 }

--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -387,14 +387,17 @@ void FileMenu::onOpenWithTriggered() {
 }
 
 void FileMenu::openFilesWithApp(GAppInfo* app) {
-    GList* uris = nullptr;
+    Fm::FilePathList paths;
     for(auto& file: files_) {
-        auto uri = file->path().uri();
-        uris = g_list_prepend(uris, uri.release());
+        paths.emplace_back(file->path());
     }
-    uris = g_list_reverse(uris); // respect the original order
-    fm_app_info_launch_uris(app, uris, nullptr, nullptr);
-    g_list_free_full(uris, g_free);
+    if(fileLauncher_) {
+        fileLauncher_->launchWithApp(nullptr, app, paths);
+    }
+    else {
+        Fm::FileLauncher launcher;
+        launcher.launchWithApp(nullptr, app, paths);
+    }
 }
 
 void FileMenu::onApplicationTriggered() {


### PR DESCRIPTION
These simple changes are needed for implementing "Recent Files" in a consistent way (→ https://github.com/lxqt/pcmanfm-qt/issues/1483).

WARNING: Recompile all libfm-qt based apps after this, especially pcmanfm-qt!