### PR TITLE
Corrected a typo that could have caused crash

### DIFF
--- a/src/core/gobjectptr.h
+++ b/src/core/gobjectptr.h
@@ -74,7 +74,7 @@ public:
 
         if(gobj_ != nullptr)
             g_object_unref(gobj_);
-        gobj_ = gobj ? reinterpret_cast<T*>(g_object_ref(gobj_)) : nullptr;
+        gobj_ = gobj ? reinterpret_cast<T*>(g_object_ref(gobj)) : nullptr;
         return *this;
     }
 


### PR DESCRIPTION
@cepamoi found it. Fortunately, the function that contained it was never used.

Closes https://github.com/lxqt/libfm-qt/issues/751