### PR TITLE
Made FolderView::selectFiles() return `bool`

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1444,9 +1444,9 @@ QModelIndex FolderView::indexFromFolderPath(const Fm::FilePath& folderPath) cons
     return QModelIndex();
 }
 
-void FolderView::selectFiles(const Fm::FileInfoList& files, bool add) {
+bool FolderView::selectFiles(const Fm::FileInfoList& files, bool add) {
     if(!model_ || files.empty()) {
-        return;
+        return false;
     }
     QModelIndex index, firstIndex;
     int count = model_->rowCount();
@@ -1484,7 +1484,9 @@ void FolderView::selectFiles(const Fm::FileInfoList& files, bool add) {
         if (singleFile) { // give focus to the single file
             selectionModel()->setCurrentIndex(firstIndex, QItemSelectionModel::Current);
         }
+        return true;
     }
+    return false;
 }
 
 Fm::FileInfoList FolderView::selectedFiles() const {

--- a/src/folderview.h
+++ b/src/folderview.h
@@ -100,7 +100,7 @@ public:
     Fm::FilePathList selectedFilePaths() const;
     bool hasSelection() const;
     QModelIndex indexFromFolderPath(const Fm::FilePath& folderPath) const;
-    void selectFiles(const Fm::FileInfoList& files, bool add = false);
+    bool selectFiles(const Fm::FileInfoList& files, bool add = false);
 
     void selectAll();
 


### PR DESCRIPTION
This is useful for knowing whether something really gets selected (`true`) or not (`false`). It'll be needed for fixing a very rare issue in pcmanfm-qt later.

WARNING: This changes API. Therefore, all libfm-qt based apps (pcmanfm-qt, lximage-qt, lxqt-archiver) should be recompiled.