### PR TITLE
Fixed file association with empty `XDG_CURRENT_DESKTOP`

### DIFF
--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -199,7 +199,7 @@ void setDefaultAppForType(const Fm::GAppInfoPtr app, std::shared_ptr<const Fm::M
     // first find the DE's mimeapps list file
     QByteArray mimeappsList = "mimeapps.list";
     QList<QByteArray> desktopsList = qgetenv("XDG_CURRENT_DESKTOP").toLower().split(':');
-    if(!desktopsList.isEmpty()) {
+    if(!desktopsList.isEmpty() && !desktopsList.at(0).isEmpty()) {
         mimeappsList = desktopsList.at(0) + "-" + mimeappsList;
     }
     QString configDir = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);


### PR DESCRIPTION
When `XDG_CURRENT_DESKTOP` is empty, GLib's function `g_app_info_get_default_for_type()` reads the default app from `~/.config/mimeapps.list`. Therefore, we should also write the default app to that file in this special case.

Fixes https://github.com/lxqt/pcmanfm-qt/issues/1510