### PR TITLE
filedialoghelper: Add protected API to internal dialog

### DIFF
--- a/src/filedialoghelper.h
+++ b/src/filedialoghelper.h
@@ -36,6 +36,9 @@ public:
 
     bool isSupportedUrl(const QUrl &url) const override;
 
+protected:
+    inline Fm::FileDialog & dialog() { return *dlg_; }
+
 private:
     void applyOptions();
     void loadSettings();


### PR DESCRIPTION
To allow descendants access to internal dialog. This is needed for e.g.
xdg-desktop-portal-lxqt for ability to inject additional options widget.

ref. lxqt/xdg-desktop-portal-lxqt#7