### PR TITLE
Fixes for `search:///` folder

### DIFF
--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -43,8 +43,9 @@ void FileInfo::setFromGFileInfo(const GObjectPtr<GFileInfo>& inf, const FilePath
     GIcon* gicon;
     GFileType type;
 
-    if (const char * name = g_file_info_get_name(inf.get()))
+    if(const char* name = g_file_info_get_name(inf.get())) {
         name_ = name;
+    }
 
     dispName_ = QString::fromUtf8(g_file_info_get_display_name(inf.get()));
 

--- a/src/core/filetransferjob.cpp
+++ b/src/core/filetransferjob.cpp
@@ -69,7 +69,9 @@ void FileTransferJob::setDestDirPath(const FilePath& destDirPath) {
         else {
             destPath = destDirPath.child(srcPath.baseName().get());
         }
-        destPaths_.emplace_back(std::move(destPath));
+        if(destPath) {
+            destPaths_.emplace_back(std::move(destPath));
+        }
     }
 }
 

--- a/src/core/totalsizejob.cpp
+++ b/src/core/totalsizejob.cpp
@@ -103,7 +103,13 @@ _retry_enum_children:
                     inf = GFileInfoPtr{g_file_enumerator_next_file(enu.get(), cancellable().get(), &err), false};
                     if(inf) {
                         FilePath child = path.child(g_file_info_get_name(inf.get()));
-                        exec(std::move(child), std::move(inf));
+                        if(!child && g_file_info_get_file_type(inf.get()) == G_FILE_TYPE_DIRECTORY) {
+                            // we won't be able to enumerate its children
+                            ++fileCount_;
+                        }
+                        else {
+                            exec(std::move(child), std::move(inf));
+                        }
                     }
                     else {
                         if(err) { /* error! */

--- a/src/filepropsdialog.cpp
+++ b/src/filepropsdialog.cpp
@@ -658,14 +658,16 @@ void FilePropsDialog::accept() {
         if(QString::fromStdString(fileInfo->name()) != new_name) {
             auto path = fileInfo->path();
             auto parent_path = path.parent();
-            auto dest = parent_path.child(new_name.toLocal8Bit().constData());
-            Fm::GErrorPtr err;
-            if(!g_file_move(path.gfile().get(), dest.gfile().get(),
-                            GFileCopyFlags(G_FILE_COPY_ALL_METADATA |
-                                           G_FILE_COPY_NO_FALLBACK_FOR_MOVE |
-                                           G_FILE_COPY_NOFOLLOW_SYMLINKS),
-                            nullptr, nullptr, nullptr, &err)) {
-                QMessageBox::critical(this, QObject::tr("Error"), err.message());
+            if(parent_path) {
+                auto dest = parent_path.child(new_name.toLocal8Bit().constData());
+                Fm::GErrorPtr err;
+                if(!g_file_move(path.gfile().get(), dest.gfile().get(),
+                                GFileCopyFlags(G_FILE_COPY_ALL_METADATA |
+                                               G_FILE_COPY_NO_FALLBACK_FOR_MOVE |
+                                               G_FILE_COPY_NOFOLLOW_SYMLINKS),
+                                nullptr, nullptr, nullptr, &err)) {
+                    QMessageBox::critical(this, QObject::tr("Error"), err.message());
+                }
             }
         }
     }

--- a/src/foldermenu.cpp
+++ b/src/foldermenu.cpp
@@ -44,7 +44,13 @@ FolderMenu::FolderMenu(FolderView* view, QWidget* parent):
 
     ProxyFolderModel* model = view_->model();
 
-    bool insideTrash(view_->path() && view_->path().hasUriScheme("trash"));
+    bool insideTrash = false;
+    bool insideSearch = false;
+    if(view_->path())
+    {
+        insideTrash = view_->path().hasUriScheme("trash");
+        insideSearch = view_->path().hasUriScheme("search");
+    }
     if(insideTrash) {
         if(auto folder = view_->folder()) {
             if(!folder->isEmpty()) {
@@ -59,7 +65,7 @@ FolderMenu::FolderMenu(FolderView* view, QWidget* parent):
             }
         }
     }
-    else {
+    else if (!insideSearch) {
         createAction_ = new QAction(tr("Create &New"), this);
         addAction(createAction_);
         createAction_->setMenu(new CreateNewMenu(view_, view_->path(), this));

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -257,6 +257,9 @@ _retry:
     }
 
     auto dest = parentDir.child(new_name.toLocal8Bit().data());
+    if(!dest) {
+        return; // e.g., with search:///
+    }
     Fm::GErrorPtr err;
     switch(type) {
     case CreateNewTextFile: {


### PR DESCRIPTION
 1. The file count in the properties dialog of `search:///` is fixed. Previously, if `search:///` contained directories, its properties dialog showed a wrong file count.
 2. "Create New" and "Paste" actions are removed from the context menu of `search:///`.
 3. The validity of some paths, that are related to `search:///`, are checked, so that critical GLib errors don't happen (and `GLib-GIO-CRITICAL` warnings don't appear in terminal).