### PR TITLE
Allow disabling smooth scrolling entirely

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -232,8 +232,6 @@ FileDialog::FileDialog(QWidget* parent, FilePath path) :
         showHiddenAction->setChecked(proxyModel_->showHidden());
         thumbnailsAction->setChecked(proxyModel_->showThumbnails());
         tooltipsAction->setChecked(!noItemTooltip_);
-        perPixelAction->setVisible(viewMode_ == FolderView::DetailedListMode
-                                   || viewMode_ == FolderView::CompactMode);
         perPixelAction->setChecked(scrollPerPixel_);
     });
 

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1690,7 +1690,7 @@ bool FolderView::eventFilter(QObject* watched, QEvent* event) {
             bool horizontal(qAbs(angleDelta.x()) > qAbs(angleDelta.y()));
             if(event->spontaneous()
                && we->source() == Qt::MouseEventNotSynthesized
-               && (scrollPerPixel_ || (mode != DetailedListMode && mode != CompactMode))
+               && scrollPerPixel_
                // To have a simpler code, we enable horizontal smooth scrolling with mouse wheel
                // only in horizontal list views.
                && (horizontalListView || !horizontal)) {


### PR DESCRIPTION
After this change, here is a test scrolling from top to bottom in `/usr/bin` (directory with lots of files) while in Icon View mode:

With smooth scrolling:
- ~3.70 seconds to scroll all the way down
- ~4.49% CPU usage (reported by QPS)

Without smooth scrolling:
- ~3.20 seconds to scroll all the way down
- ~2.83% CPU usage (reported by QPS)

It feels much more responsive overall and it's less obnoxious without the animation.

String update: https://github.com/lxqt/pcmanfm-qt/pull/1573