### PR TITLE
Fixed crash with empty URI scheme of folder path

### DIFF
--- a/src/core/folder.cpp
+++ b/src/core/folder.cpp
@@ -532,7 +532,7 @@ void Folder::onDirListFinished() {
     const auto& infos = job->files();
 
     // with "search://", there is no update for infos and all of them should be added
-    if(strcmp(dirPath_.uriScheme().get(), "search") == 0) {
+    if(dirPath_.hasUriScheme("search")) {
         files_to_add = infos;
         for(auto& file: files_to_add) {
             files_[file->path().baseName().get()] = file;


### PR DESCRIPTION
An empty URI scheme is possible when trying to open a folder with an empty path (like when the desktop path is empty and pcmanfm-qt's desktop module is started).

Fixes https://github.com/lxqt/lxqt-session/issues/439