### PR TITLE
Allow remembering the result of execution prompt for multiple files

### DIFF
--- a/src/exec-file.ui
+++ b/src/exec-file.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>487</width>
-    <height>58</height>
+    <height>87</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -86,6 +86,17 @@
        </property>
        <property name="icon">
         <iconset theme="dialog-cancel"/>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="remLayout">
+     <item>
+      <widget class="QCheckBox" name="remBox">
+       <property name="text">
+        <string>Remember for next files of this kind</string>
        </property>
       </widget>
      </item>

--- a/src/execfiledialog.cpp
+++ b/src/execfiledialog.cpp
@@ -54,10 +54,20 @@ ExecFileDialog::ExecFileDialog(const FileInfo &fileInfo, QWidget* parent, Qt::Wi
         ui->open->hide();
     }
     ui->msg->setText(msg);
+    ui->remBox->hide();
 }
 
 ExecFileDialog::~ExecFileDialog() {
     delete ui;
+}
+
+void ExecFileDialog::allowRemembering() {
+    ui->remLayout->setContentsMargins(0, 10, 0, 0);
+    ui->remBox->show();
+}
+
+bool ExecFileDialog::isRemembered() {
+    return ui->remBox->isChecked();
 }
 
 void ExecFileDialog::accept() {

--- a/src/execfiledialog_p.h
+++ b/src/execfiledialog_p.h
@@ -43,6 +43,9 @@ public:
     return result_;
   }
 
+  void allowRemembering();
+  bool isRemembered();
+
 protected:
   void accept() override;
   void reject() override;

--- a/src/filelauncher.h
+++ b/src/filelauncher.h
@@ -53,6 +53,15 @@ protected:
 
     virtual void launchedFiles(const FileInfoList& files) const;
     virtual void launchedPaths(const FilePathList& paths) const;
+
+private:
+    void resetExecActions();
+
+private:
+    bool multiple_;
+    BasicFileLauncher::ExecAction dekstopEntryAction_;
+    BasicFileLauncher::ExecAction scriptAction_;
+    BasicFileLauncher::ExecAction execAction_;
 };
 
 }


### PR DESCRIPTION
When multiple executable files are going to be launched, the execution prompt dialog gets a checkbox for remembering the user's action for next files of the same kind.

If you've selected 10 desktop entries inside `/usr/share/applications` and pressed `Enter` by mistake, you know why this is necessary.

WARNING: `pcmanfm-qt` and other apps that depend on `libfm-qt` should be recompiled after applying this patch.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1616