### PR TITLE
Fixed file deselection in LXQt file dialog

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -800,6 +800,7 @@ void FileDialog::onCurrentRowChanged(const QModelIndex &current, const QModelInd
 void FileDialog::onSelectionChanged(const QItemSelection& /*selected*/, const QItemSelection& /*deselected*/) {
     auto selFiles = ui->folderView->selectedFiles();
     if(selFiles.empty()) {
+        ui->fileName->clear();
         updateAcceptButtonState();
         updateSaveButtonText(false);
         return;
@@ -841,9 +842,8 @@ void FileDialog::onSelectionChanged(const QItemSelection& /*selected*/, const QI
         }
     }
     // put the selection list in the text entry
-    if(!fileNames.isEmpty()) {
-        ui->fileName->setText(fileNames);
-    }
+    ui->fileName->setText(fileNames);
+
     updateSaveButtonText(hasDir);
     updateAcceptButtonState();
 }


### PR DESCRIPTION
Previously, if a single file was selected and then deselected, the file name entry wouldn't be emptied and the deselected file would be opened on pressing `Open`. There were other scenarios too.

Fixes https://github.com/lxqt/libfm-qt/issues/828

NOTE: I'll rebase the Qt6 branch soon.