### PR TITLE
Rubber-band selection in list mode from non-name columns

### DIFF
--- a/src/folderview_p.h
+++ b/src/folderview_p.h
@@ -144,7 +144,6 @@ private:
   // for rubberband
   QPoint mousePressPoint_;
   QRect rubberBandRect_;
-  QItemSelectionModel::SelectionFlag ctrlDragSelectionFlag_;
 };
 
 


### PR DESCRIPTION
Opening items by clicking a non-name column is kept intact in the single-click mode.

Also, fixed a bug in the rubber-band selection with RTL layouts.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1633

NOTE: I'll rebase the Qt6 branch soon.