### PR TITLE
No activation in list mode if selection rectangle exceeds drag distance

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -807,7 +807,10 @@ void FolderViewTreeView::queueLayoutColumns() {
 
 void FolderViewTreeView::mouseReleaseEvent(QMouseEvent* event) {
     bool activationWasAllowed = activationAllowed_;
-    if((!style()->styleHint(QStyle::SH_ItemView_ActivateItemOnSingleClick, nullptr, this)) || (event->button() != Qt::LeftButton)) {
+    if(!style()->styleHint(QStyle::SH_ItemView_ActivateItemOnSingleClick, nullptr, this)
+       || event->button() != Qt::LeftButton
+       // also, prevent activation if rubberband selection is greater than dragging distance
+       || rubberBandRect_.width() + rubberBandRect_.height() > QApplication::startDragDistance()) {
         activationAllowed_ = false;
     }
 


### PR DESCRIPTION
This is another improvement to UX in the detailed list mode.

If the user drags the cursor on a non-name column and releases the left mouse button on the same column, activation will occur only with a small enough selection rectangle (whose "Manhattan length" doesn't exceed the dragging distance).