### PR TITLE
Restored deselection behavior of LXQt file dialog

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -806,7 +806,6 @@ void FileDialog::onCurrentRowChanged(const QModelIndex &current, const QModelInd
 void FileDialog::onSelectionChanged(const QItemSelection& /*selected*/, const QItemSelection& /*deselected*/) {
     auto selFiles = ui->folderView->selectedFiles();
     if(selFiles.empty()) {
-        ui->fileName->clear();
         updateAcceptButtonState();
         updateSaveButtonText(false);
         return;
@@ -848,8 +847,9 @@ void FileDialog::onSelectionChanged(const QItemSelection& /*selected*/, const QI
         }
     }
     // put the selection list in the text entry
-    ui->fileName->setText(fileNames);
-
+    if(!fileNames.isEmpty()) {
+        ui->fileName->setText(fileNames);
+    }
     updateSaveButtonText(hasDir);
     updateAcceptButtonState();
 }


### PR DESCRIPTION
It's the behavior of the default Qt file dialog (and perhaps other file dialogs).

Contrary to my arguments at https://github.com/lxqt/libfm-qt/issues/828, there are several reasons as to why it's the best behavior (although, perhaps, not intuitive at first glance).

This just reverts https://github.com/lxqt/libfm-qt/commit/0719f8d9b07a071017b7814b10d3719fe1f2cc68

Sorry for the inconvenience!