### PR TITLE
Corrected the position of drop menu under Wayland

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1609,7 +1609,7 @@ void FolderView::childDropEvent(QDropEvent* e) {
         if(info && info->isWritableDirectory() && info->isWritable()) {
             actions = e->possibleActions();
         }
-        Qt::DropAction action = DndActionMenu::askUser(actions, QCursor::pos());
+        Qt::DropAction action = DndActionMenu::askUser(actions, view->viewport()->mapToGlobal(e->pos()));
         e->setDropAction(action);
     }
 }


### PR DESCRIPTION
During DND under Wayland, `QCursor::pos()` isn't reliable for getting the cursor's "global" position (which is really not global but calculated relative to the parent widget). Instead, `QDropEvent::pos()` should be mapped by using `QWidget::mapToGlobal()`.

Although this is logical under X11 too, it makes no difference there.