### PR TITLE
Fixed crash with DND into side-pane under Wayland

### DIFF
--- a/src/dirtreemodel.cpp
+++ b/src/dirtreemodel.cpp
@@ -90,9 +90,9 @@ QVariant DirTreeModel::data(const QModelIndex& index, int role) const {
 bool DirTreeModel::dropMimeData(const QMimeData* data, Qt::DropAction /*action*/, int /*row*/, int /*column*/, const QModelIndex& parent) {
     if(auto destPath = filePath(parent)) {
         if(data->hasUrls()) { // files uris are dropped
-            Qt::DropAction action = DndActionMenu::askUser(Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, QCursor::pos());
             auto paths = pathListFromQUrls(data->urls());
             if(!paths.empty()) {
+                Qt::DropAction action = DndActionMenu::askUser(Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, QCursor::pos());
                 switch(action) {
                 case Qt::CopyAction:
                     FileOperation::copyFiles(paths, destPath);

--- a/src/placesmodel.cpp
+++ b/src/placesmodel.cpp
@@ -591,9 +591,9 @@ bool PlacesModel::dropMimeData(const QMimeData* data, Qt::DropAction /*action*/,
                     PlacesModelItem* placesItem = static_cast<PlacesModelItem*>(item);
                     auto destPath = placesItem->path();
                     if(destPath) {
-                        Qt::DropAction action = DndActionMenu::askUser(Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, QCursor::pos());
                         auto paths = pathListFromQUrls(data->urls());
                         if(!paths.empty()) {
+                            Qt::DropAction action = DndActionMenu::askUser(Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, QCursor::pos());
                             switch(action) {
                             case Qt::CopyAction:
                                 FileOperation::copyFiles(paths, destPath);


### PR DESCRIPTION
The patch is safer with X11 too because it gets the required info before showing the DND menu.

Fixes https://github.com/lxqt/libfm-qt/issues/838

NOTE: The misplacement of the DND menu can't be fixed in this case because the relevant classes don't include the required info. Unless Qt finds solutions/workarounds for Wayland nonsenses, Wayland users should tolerate them.