### PR TITLE
Specified the parents of context menus for use on Wayland

### DIFF
--- a/src/dirtreeview.cpp
+++ b/src/dirtreeview.cpp
@@ -201,7 +201,7 @@ void DirTreeView::onCustomContextMenuRequested(const QPoint& pos) {
             auto path = fileInfo->path();
             Fm::FileInfoList files ;
             files.push_back(fileInfo);
-            Fm::FileMenu* menu = new Fm::FileMenu(files, fileInfo, path);
+            Fm::FileMenu* menu = new Fm::FileMenu(files, fileInfo, path, true, QString(), this);
             // FIXME: apply some settings to the menu and set a proper file launcher to it
             Q_EMIT prepareFileMenu(menu);
 

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1950,7 +1950,7 @@ void FolderView::onFileClicked(int type, const std::shared_ptr<const Fm::FileInf
             }
         }
         if (!menu && folderInfo()) {
-            Fm::FolderMenu* folderMenu = new Fm::FolderMenu(this);
+            Fm::FolderMenu* folderMenu = new Fm::FolderMenu(this, this);
             prepareFolderMenu(folderMenu);
             menu = folderMenu;
         }

--- a/src/placesview.cpp
+++ b/src/placesview.cpp
@@ -471,7 +471,7 @@ void PlacesView::contextMenuEvent(QContextMenuEvent* event) {
         // Do not take the ownership of the menu since
         // it will be deleted with deleteLater() upon hidden.
         // This is possibly related to #145 - https://github.com/lxqt/pcmanfm-qt/issues/145
-        QMenu* menu = new QMenu();
+        QMenu* menu = new QMenu(this);
         QAction* action = nullptr;
         PlacesModelItem* item = static_cast<PlacesModelItem*>(model_->itemFromIndex(proxyModel_->mapToSource(index)));
 

--- a/src/placesview.cpp
+++ b/src/placesview.cpp
@@ -468,9 +468,10 @@ void PlacesView::contextMenuEvent(QContextMenuEvent* event) {
             index = index.sibling(index.row(), 0);
         }
 
-        // Do not take the ownership of the menu since
-        // it will be deleted with deleteLater() upon hidden.
-        // This is possibly related to #145 - https://github.com/lxqt/pcmanfm-qt/issues/145
+        // The ownership of the menu is taken because that may be needed for
+        // correct positioning under Wayland, especially when the window is
+        // inactive (it is safe under X11), but the menu will be deleted by
+        // deleteLater() when it is going to hide.
         QMenu* menu = new QMenu(this);
         QAction* action = nullptr;
         PlacesModelItem* item = static_cast<PlacesModelItem*>(model_->itemFromIndex(proxyModel_->mapToSource(index)));


### PR DESCRIPTION
On Wayland, a parentless context menu might have a window decoration and pop up in an incorrect position if the window is inactive when right clicked. The patch prevents the problem by specifying the parents of folder and side-pane context menus.

There will be no change on X11.