### PR TITLE
appchooser: don't disable the OK button

### DIFF
--- a/src/appchooserdialog.cpp
+++ b/src/appchooserdialog.cpp
@@ -253,6 +253,11 @@ void AppChooserDialog::accept() {
 }
 
 void AppChooserDialog::onSelectionChanged() {
+    if(ui->tabWidget->currentIndex() != 0) {
+        // the selection may be reset by menu-cache,
+        // while the app menu view is not shown
+        return;
+    }
     bool isAppSelected = ui->appMenuView->isAppSelected();
     ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(isAppSelected);
 }


### PR DESCRIPTION
When we are not in the app view tab don't change the enable state of the OK button, only because we lost the focus from the app on the app view.

In the appchooser dialog, sometime we loose the active status of the OK button in the "custom command" tab.
This happens because if in the "Installed Application" tab the selection is lost, then the "OK button enable status" is disabled.

This patch ensures that the OK button state is changed only when the "Installed Application" tab is shown.