### PR TITLE
Increased the minimum width of name column in list view

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -401,7 +401,7 @@ void FolderViewTreeView::setHiddenColumns(const QSet<int> &columns) {
 }
 
 void FolderViewTreeView::headerContextMenu(const QPoint &p) {
-    QMenu menu;
+    QMenu menu(header()); // a parent is needed under Wayland for correct positioning
     QAction *action = menu.addAction (tr("Auto-resize columns"));
     action->setCheckable(true);
     action->setChecked(customColumnWidths_.isEmpty());
@@ -720,8 +720,11 @@ void FolderViewTreeView::layoutColumns() {
                 // Compute the width available for the filename column
                 int filenameAvailWidth = availWidth - desiredWidth + widths.at(filenameColumn);
 
-                // Compute the minimum acceptable width for the filename column
-                int filenameMinWidth = qMin(200, sizeHintForColumn(filenameColumn));
+                // Compute the minimum acceptable width for the filename column,
+                // showing whole texts whose lengths are less than 50 times the space width.
+                int filenameMinWidth = qMin(iconSize().width()
+                                            + 50 * opt.fontMetrics.horizontalAdvance(QLatin1Char(' ')),
+                                            sizeHintForColumn(filenameColumn));
 
                 if(filenameAvailWidth > filenameMinWidth) {
                     // Shrink the filename column to the available width


### PR DESCRIPTION
Previously, it was 200px, which might not be enough with wide fonts. This patch changes it to 50 times the space width plus icon width. It's usually more than 200px even with a small font size of 9.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1696