### PR TITLE
Use average font width to set min. width of name column

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -720,10 +720,10 @@ void FolderViewTreeView::layoutColumns() {
                 // Compute the width available for the filename column
                 int filenameAvailWidth = availWidth - desiredWidth + widths.at(filenameColumn);
 
-                // Compute the minimum acceptable width for the filename column,
-                // showing whole texts whose lengths are less than 50 times the space width.
+                // Compute the minimum acceptable width for the filename column, showing
+                // whole texts whose lengths are less than 30 times the average font width.
                 int filenameMinWidth = qMin(iconSize().width()
-                                            + 50 * opt.fontMetrics.horizontalAdvance(QLatin1Char(' ')),
+                                            + 30 * opt.fontMetrics.averageCharWidth(),
                                             sizeHintForColumn(filenameColumn));
 
                 if(filenameAvailWidth > filenameMinWidth) {


### PR DESCRIPTION
It gives a more predictable width and is more consistent with other parts of the code.

30 times the average font width is used.