### PR TITLE
Fixed DND menu position with DND between windows under Wayland

### DIFF
--- a/src/dndactionmenu.cpp
+++ b/src/dndactionmenu.cpp
@@ -46,9 +46,9 @@ DndActionMenu::~DndActionMenu() {
 
 }
 
-Qt::DropAction DndActionMenu::askUser(Qt::DropActions possibleActions, QPoint pos) {
+Qt::DropAction DndActionMenu::askUser(Qt::DropActions possibleActions, QPoint pos, QWidget* parent) {
     Qt::DropAction result = Qt::IgnoreAction;
-    DndActionMenu menu{possibleActions};
+    DndActionMenu menu{possibleActions, parent};
     QAction* action = menu.exec(pos);
     if(nullptr != action) {
         if(action == menu.copyAction) {

--- a/src/dndactionmenu.h
+++ b/src/dndactionmenu.h
@@ -33,7 +33,7 @@ public:
     explicit DndActionMenu(Qt::DropActions possibleActions, QWidget* parent = nullptr);
     ~DndActionMenu() override;
 
-    static Qt::DropAction askUser(Qt::DropActions possibleActions, QPoint pos);
+    static Qt::DropAction askUser(Qt::DropActions possibleActions, QPoint pos, QWidget* parent = nullptr);
 
 private:
     QAction* copyAction;

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1612,7 +1612,10 @@ void FolderView::childDropEvent(QDropEvent* e) {
         if(info && info->isWritableDirectory() && info->isWritable()) {
             actions = e->possibleActions();
         }
-        Qt::DropAction action = DndActionMenu::askUser(actions, view->viewport()->mapToGlobal(e->pos()));
+        Qt::DropAction action = DndActionMenu::askUser(actions,
+                                                       view->viewport()->mapToGlobal(e->pos()),
+                                                       // a parent is needed under Wayland for correct positioning
+                                                       view->viewport());
         e->setDropAction(action);
     }
 }


### PR DESCRIPTION
Made the DND menu a child of the viewport; otherwise, the DND menu position will be incorrect under Wayland when files are dragged from a window and dropped into another.

NOTE: To be on the safe side, recompile pcmanfm-qt and apps that are based on libfm-qt.