### PR TITLE
Prevent DND crash from outside app under Wayland

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1597,9 +1597,13 @@ void FolderView::childDropEvent(QDropEvent* e) {
         return;
     }
 
-    if(e->keyboardModifiers() == Qt::NoModifier) {
-        // if no key modifiers are used, popup a menu
-        // to ask the user for the action he/she wants to perform.
+    // If no key modifiers are used, pop up a menu
+    // to ask the user for the action he/she wants to perform.
+    if(e->keyboardModifiers() == Qt::NoModifier
+       // WARNING: When the drag source is outside the app, showing a popup menu makes Wayland free
+       // the mime data of the drop event and so, a crash will happen in FolderModel::dropMimeData().
+       // As a workaround, we just accept the proposed action in this case.
+       && !(e->source() == nullptr && QGuiApplication::platformName() == QStringLiteral("wayland"))) {
         Qt::DropActions actions = Qt::IgnoreAction;
         std::shared_ptr<const Fm::FileInfo> info = nullptr;
         if(model_) {


### PR DESCRIPTION
By accepting the proposed action and not showing a DND menu.

Showing a DND menu and waiting for the user's response makes Wayland free the mime data and create a dangling pointer, which will cause a crash on accepting the DND.

Closes https://github.com/lxqt/libfm-qt/issues/860