### PR TITLE
Fixed crash with DND from outside app under Wayland

### DIFF
--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -588,7 +588,8 @@ bool FolderModel::dropMimeData(const QMimeData* data, Qt::DropAction action, int
         srcPaths = Fm::pathListFromQUrls(data->urls());
     }
 
-    // FIXME: should we put this in dropEvent handler of FolderView instead?
+    // NOTE: If the DND is done with no key modifier, the current method will not be called.
+    // Instead, the dropEvent handler of FolderView will do the job after asking the user.
     if(!srcPaths.empty()) {
         //qDebug("drop action: %d", action);
         switch(action) {


### PR DESCRIPTION
A drag and drop from outside the app resulted in a crash under Wayland because Wayland freed the DND mime data once the DND menu was shown, leaving a dangling pointer, which caused the crash on accepting the DND.

This patch fixes the issue by processing the DND mime data only before showing the DND menu. X11 sees no change.

NOTE: This is rather a workaround for a Qt problem. Qt's DND needs fixes for Wayland, so that such a situation becomes impossible.

Fixes https://github.com/lxqt/libfm-qt/issues/860