### PR TITLE
Fixed unresponsive DND menu under Wayland

### DIFF
--- a/src/dirtreemodel.cpp
+++ b/src/dirtreemodel.cpp
@@ -19,7 +19,6 @@
 
 #include "dirtreemodel.h"
 #include "dirtreemodelitem.h"
-#include "dndactionmenu.h"
 #include "fileoperation.h"
 #include "utilities.h"
 #include <QDebug>
@@ -87,12 +86,11 @@ QVariant DirTreeModel::data(const QModelIndex& index, int role) const {
     return QVariant();
 }
 
-bool DirTreeModel::dropMimeData(const QMimeData* data, Qt::DropAction /*action*/, int /*row*/, int /*column*/, const QModelIndex& parent) {
+bool DirTreeModel::dropMimeData(const QMimeData* data, Qt::DropAction action, int /*row*/, int /*column*/, const QModelIndex& parent) {
     if(auto destPath = filePath(parent)) {
         if(data->hasUrls()) { // files uris are dropped
             auto paths = pathListFromQUrls(data->urls());
             if(!paths.empty()) {
-                Qt::DropAction action = DndActionMenu::askUser(Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, QCursor::pos());
                 switch(action) {
                 case Qt::CopyAction:
                     FileOperation::copyFiles(paths, destPath);

--- a/src/dirtreeview.h
+++ b/src/dirtreeview.h
@@ -54,6 +54,7 @@ public:
 protected:
     void mousePressEvent(QMouseEvent* event) override;
     void rowsAboutToBeRemoved(const QModelIndex& parent, int start, int end) override;
+    void dropEvent(QDropEvent* event) override;
 
 private:
     void cancelPendingChdir();

--- a/src/placesmodel.cpp
+++ b/src/placesmodel.cpp
@@ -27,7 +27,6 @@
 #include <QStandardPaths>
 #include "utilities.h"
 #include "placesmodelitem.h"
-#include "dndactionmenu.h"
 #include "fileoperation.h"
 
 namespace Fm {
@@ -537,7 +536,7 @@ std::shared_ptr<PlacesModel> PlacesModel::globalInstance() {
 }
 
 
-bool PlacesModel::dropMimeData(const QMimeData* data, Qt::DropAction /*action*/, int row, int column, const QModelIndex& parent) {
+bool PlacesModel::dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent) {
     QStandardItem* item = itemFromIndex(parent);
     if(data->hasFormat(QStringLiteral("application/x-bookmark-row"))) { // the data being dopped is a bookmark row
         // decode it and do bookmark reordering
@@ -581,7 +580,6 @@ bool PlacesModel::dropMimeData(const QMimeData* data, Qt::DropAction /*action*/,
                 if (item == trashItem_) {
                     auto paths = pathListFromQUrls(data->urls());
                     if(!paths.empty()) {
-                        Qt::DropAction action = DndActionMenu::askUser(Qt::MoveAction, QCursor::pos());
                         if (action == Qt::MoveAction) {
                             FileOperation::trashFiles(paths, false);
                         }
@@ -593,7 +591,6 @@ bool PlacesModel::dropMimeData(const QMimeData* data, Qt::DropAction /*action*/,
                     if(destPath) {
                         auto paths = pathListFromQUrls(data->urls());
                         if(!paths.empty()) {
-                            Qt::DropAction action = DndActionMenu::askUser(Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, QCursor::pos());
                             switch(action) {
                             case Qt::CopyAction:
                                 FileOperation::copyFiles(paths, destPath);


### PR DESCRIPTION
Under Wayland, not only the DND menu was unresponsive to mouseover, it might also cause a crash if Escape was pressed (twice).

The reason was that the menu was shown synchronously, before the DND was finished. This patch fixes the issue by showing the menu after finishing the DND (which is OK under X11 too).

Also, corrected the position of the side-pane DND menu under Wayland.

NOTE: Avoiding `QMenu::exec()` and using `QMenu::popup()` with signals and slots would be a cleaner solution. However, the current solution is much simpler and works fine. At some point, I might change the code to avoid `QMenu::exec()` as far as possible.

Fixes https://github.com/lxqt/libfm-qt/issues/863