### PR TITLE
Check mime data of clipboard for nullity

### DIFF
--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -187,6 +187,9 @@ void FolderModel::updateCutFilesSet() {
     bool cutPathFound = false;
     const QClipboard* clipboard = QApplication::clipboard();
     const QMimeData* data = clipboard->mimeData();
+    if(data == nullptr) {
+        return; // possible under Wayland
+    }
 
     // Gnome, LXDE, XFCE (see utilities.cpp -> pasteFilesFromClipboard)
     if(data->hasFormat(QStringLiteral("x-special/gnome-copied-files"))) {

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -70,6 +70,9 @@ Fm::FilePathList pathListFromQUrls(QList<QUrl> urls) {
 void pasteFilesFromClipboard(const Fm::FilePath& destPath, QWidget* parent) {
     QClipboard* clipboard = QApplication::clipboard();
     const QMimeData* data = clipboard->mimeData();
+    if(data == nullptr) {
+        return; // possible under Wayland
+    }
     Fm::FilePathList paths;
     bool isCut = false;
 


### PR DESCRIPTION
`QClipboard::mimeData()` can be null under Wayland (although it hasn't been with Wayland compositors I've tried). Moreover, Qt doesn't guarantee that it's valid everywhere.

The patch adds a nullity check.