### PR TITLE
Fixed drawing of selection rectangle under Wayland

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -85,6 +85,7 @@ FolderViewListView::~FolderViewListView() {
 }
 
 void FolderViewListView::startDrag(Qt::DropActions supportedActions) {
+    mouseLeftPressed_ = false; // see FolderViewListView::mouseMoveEvent
     if(movement() != Static) {
         QListView::startDrag(supportedActions);
     }


### PR DESCRIPTION
Under Wayland, `QApplication::mouseButtons()` isn't updated after a drag-and-drop, until somewhere inside the app's GUI is clicked. That can interfere with the selection rectangle (= rubber-band) in rare cases.

The patch avoids the problem by forgetting the mouse press as soon as a drag starts. X11 sees no difference.

A way of reproducing the issue:

 1. In the icon mode and inside a folder that has enough files for being scrolled, drag a file and drop it outside pcmanfm-qt (outside its desktop too). For example, you can drag a text file and drop it into FeatherPad.
 2. Without clicking anywhere, move the cursor over that folder and turn the mouse wheel.

Without this patch, a selection rectangle is drawn, while no mouse button is pressed.

NOTE: Auto-selection with delay suffers from the same symptom: it doesn't work after drag-and-drop, until somewhere is clicked. Sadly, there's no single-line workaround for it, and I don't think this Wayland annoyance is worth adding more codes.