### PR TITLE
Announce user's decision about DND

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1655,6 +1655,8 @@ void FolderView::childDropEvent(QDropEvent* e) {
                     break;
                 }
 
+                Q_EMIT dropIsDecided(action != Qt::IgnoreAction);
+
                 switch(action) {
                 case Qt::CopyAction:
                     FileOperation::copyFiles(srcPaths, destPath);
@@ -1670,8 +1672,13 @@ void FolderView::childDropEvent(QDropEvent* e) {
                 }
             });
             e->accept(); // prevent further event propagation
+            return;
         }
     }
+
+    QTimer::singleShot(0, view, [this] {
+        Q_EMIT dropIsDecided(true); // after finishing drop
+    });
 }
 
 bool FolderView::eventFilter(QObject* watched, QEvent* event) {

--- a/src/folderview.h
+++ b/src/folderview.h
@@ -192,6 +192,8 @@ Q_SIGNALS:
 
     void inlineRenamed(const QString& oldName, const QString& newName);
 
+    void dropIsDecided(bool accepted);
+
 private:
 
     QAbstractItemView* view;


### PR DESCRIPTION
This will be used in `pcmanfm-qt` to fix a small regression that was caused by showing DND menu after finishing DND (for Wayland).