### PR TITLE
Generalized the option for disabling smooth scrolling

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -238,8 +238,6 @@ FileDialog::FileDialog(QWidget* parent, FilePath path) :
         showHiddenAction->setChecked(proxyModel_->showHidden());
         thumbnailsAction->setChecked(proxyModel_->showThumbnails());
         tooltipsAction->setChecked(!noItemTooltip_);
-        perPixelAction->setVisible(viewMode_ == FolderView::DetailedListMode
-                                   || viewMode_ == FolderView::CompactMode);
         perPixelAction->setChecked(scrollPerPixel_);
     });
 


### PR DESCRIPTION
Now, the option disables smooth scrolling in all view modes.

Unlike before, the tweaks for wheel scroll speed will be preserved if smooth scrolling is disabled (e.g., slower scrolling of big thumbnails).

This PR will be followed by a simple PR for pcmanfm-qt, in which only a label will change.