### PR TITLE
Open non-executable files that have executable file type

### DIFF
--- a/src/core/basicfilelauncher.cpp
+++ b/src/core/basicfilelauncher.cpp
@@ -421,6 +421,9 @@ bool BasicFileLauncher::launchExecutable(const FileInfoPtr &fileInfo, GAppLaunch
             break;
         }
     }
+    else { // launch it if it has executable file type but is not really executable
+        return launchWithDefaultApp(fileInfo, ctx);
+    }
     return false;
 }
 

--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -305,7 +305,10 @@ FileMenu::~FileMenu() {
 }
 
 void FileMenu::addTrustAction() {
-    if(info_->isExecutableType()) {
+    if(info_->isExecutableType()
+       // check if it is really executable and not just an executable file type
+       && (info_->isDesktopEntry()
+           || g_file_test(info_->path().localPath().get(), G_FILE_TEST_IS_EXECUTABLE))) {
         QAction* trustAction = new QAction(files_.size() > 1
                                              ? tr("Trust selected executables")
                                              : tr("Trust this executable"),


### PR DESCRIPTION
That is possible not only with non-executable scripts that are executable for root, but also with non-text files like AppImage: an AppImage file may be opened by an archive manager that supports it, although its file type is executable (i.e., a subclass of `application/x-executable`).

Fixes https://github.com/lxqt/pcmanfm-qt/issues/1717