### PR TITLE
Keep selection and tree expansion in app chooser dialog

### DIFF
--- a/src/appmenuview.h
+++ b/src/appmenuview.h
@@ -62,6 +62,10 @@ private:
 
     AppMenuViewItem* selectedItem() const;
 
+    QModelIndex indexForId(const QByteArray& id, bool isDir, const QModelIndex& index = QModelIndex()) const;
+    QSet<QByteArray> getExpanded(const QModelIndex& index = QModelIndex()) const;
+    void restoreExpanded(const QSet<QByteArray>& expanded, const QModelIndex& index = QModelIndex());
+
 private:
     // gboolean fm_app_menu_view_is_item_app(, GtkTreeIter* it);
     QStandardItemModel* model_;


### PR DESCRIPTION
Previously, the selection and expansion state were lost when menu-cache was reloaded.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1733