### PR TITLE
Typo fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -284,7 +284,7 @@ libfm-qt-0.13.0 / 2018-05-21
   * Delete the unused old FmTemplate wrapper.
   * Create the template items in the "Create New" menu with the new C++ file template APIs.
   * Port template support to C++ (Fm::Templates class).
-  * Add convinient functions in Fm::FileOperation to set dest paths for file transfer jobs.
+  * Add convenient functions in Fm::FileOperation to set dest paths for file transfer jobs.
   * Made job async again
   * Fixed launching of desktop files
   * Cleanup
@@ -301,7 +301,7 @@ libfm-qt-0.13.0 / 2018-05-21
   * Elided labels for file operation dialog
   * fix namespace, fixes lxqt/libfm-qt/issues/174
   * Misc link fixes
-  * Fixes some pathes after repo move
+  * Fixes some paths after repo move
   * Fix a cause of crash in `AppChooserComboBox`
   * build: Bump version
   * Drop Fm::IconTheme
@@ -421,7 +421,7 @@ libfm-qt-0.12.0 / 2017-10-21
   * folderview: Don't allow D&D by Back or Forward
   * More fixes (#87)
   * Added a missing change signal (#86)
-  * Fix single items when seaching (#85)
+  * Fix single items when searching (#85)
   * Check for nullity of IconInfo (#84)
   * Address compiler warnings
   * Remove addRoots() return type
@@ -513,7 +513,7 @@ libfm-qt-0.12.0 / 2017-10-21
   * Implement VolumeManager class which is a QObject wrapper of gio GVolumeMonitor.
   * Add some getters for Volume and Mount classes.
   * Properly associate external thumbnailers with mimetypes they support and fix thumbnail generation from thumbnailers.
-  * Start porting thumbnail loaders to the new C++ APIs. Add new Fm::ThumbnailJob used to load thumbnails for a given file list. Add commonDirPath paramter to Fm::FileInfoJob to reduce memory usage.
+  * Start porting thumbnail loaders to the new C++ APIs. Add new Fm::ThumbnailJob used to load thumbnails for a given file list. Add commonDirPath parameter to Fm::FileInfoJob to reduce memory usage.
   * Add the missing test case for folder view.
   * Start porting Fm::FolderModel and Fm::FolderView to the new libfm core c++ API.
   * Work in progress.
@@ -742,8 +742,8 @@ libfm-qt-0.11.0 / 2016-02-27
   * Add more null checks.
   * Portuguese update
   * Add very basic "remaining time" display to the progress dialog. Fix lxde/lxqt#463 - Progress dialog of pcmanfm-qt does not show remaining time.
-  * Fix lxde/pcmanfm-qt#120 - Foucs "Rename" button when file name changed.
-  * Remove unnecessary '\n' charactor from the translated strings.
+  * Fix lxde/pcmanfm-qt#120 - Focus "Rename" button when file name changed.
+  * Remove unnecessary '\n' character from the translated strings.
   * Fix translations (the newly added string comes from the translation of libfm).
   * Improve trash can handling: provide an option to delete the files if moving to trashcan fails.
   * Fix broken filenames of translation files.
@@ -788,7 +788,7 @@ libfm-qt-0.11.0 / 2016-02-27
   * Improve handling of fallback icons. This closes bug #57.
   * Translations are lost accidentally in a previous commit. Restore them all.
   * Fix a crash in Fm::PlacesModel when gvfs is not available. This closes bug #35 - Ctrl+W closes all windows.
-  * Do not detect filename extension and select the whole filename by default while renaming directories. This closes bug #71 - Don't try to detect extensions on directories. * API changed: Fm::renameFile() now accepect FmFileInfo as its first parameter.
+  * Do not detect filename extension and select the whole filename by default while renaming directories. This closes bug #71 - Don't try to detect extensions on directories. * API changed: Fm::renameFile() now accept FmFileInfo as its first parameter.
   * Fix bug #80 - make execute in context menu doesn't do change permissions.
   * Revert "fixed selection issue #45" This patch breaks copying files by DND in icon view mode and moving desktop icons.
   * Use qss instead of QPalette to set the background color of ColorButton. This fixed bug #192 of lxde-qt.
@@ -821,7 +821,7 @@ libfm-qt-0.11.0 / 2016-02-27
   * Implement Fm::AppChooserDialog and Fm::AppMenuView classes. * Add <Open with...>/<Other Applications> menu item to Fm::FileMenu. * Add custom app to Fm::AppChooserComboBox.
   * Add Fm::AppChooserComboBox and use it in Fm::FilePropsDialog.
   * Redesign Fm::FileLauncher APIs to make it more usable. * Add Fm::FileMenu::setFileLauncher() and Fm::FolderView::setFileLauncher() APIs. * Move PCManFM::View::onFileClick() and other popup menu handling to Fm::FolderView.
-  * Improve Fm::FileLaucher to make it easy to derive subclasses. * Implement a special dialog for opening executable files (Fix bug #13 - it does not launch executables)
+  * Improve Fm::FileLauncher to make it easy to derive subclasses. * Implement a special dialog for opening executable files (Fix bug #13 - it does not launch executables)
   * Fix bug #28 - Tash can icon does not refresh when the trash can changes its empty/full status
   * Load autocompletion list for Fm::PathEdit only when the widget has the keyboard focus to avoid unnecessary I/O.
   * Add proper popup menu items for selected folders and fix #20 and #19. * Some code refactors, adding openFolders() and openFolderInTerminal() to Application class.
@@ -843,7 +843,7 @@ libfm-qt-0.11.0 / 2016-02-27
   * Move some code from Fm::DirTreeModel to Fm::DirTreeModelItem.
   * Partially implement Fm::DirTreeView and Fm::DirTreeModel. (not finished yet)
   * Fix an invalid pointer
-  * Implment different modes for Fm::SidePane, matching libfm-qtk design. * Add basic skeleton for dir tree view/model.
+  * Implement different modes for Fm::SidePane, matching libfm-qtk design. * Add basic skeleton for dir tree view/model.
   * Fix the cosmetic defect introduced by the eject buttons in the places view.
   * Add eject buttons to mounted volumes in the places side pane.
   * Add a wrapper class Fm::Path for FmPath C struct.
@@ -866,7 +866,7 @@ libfm-qt-0.11.0 / 2016-02-27
   * Reduce memory usage: Paint the folder items with our own code instead of using a dirty hacks duplicating pixmaps.
   * Reduce of size of QPixmapCache in the hope of decreasing memory usage.
   * Add fallback icons for places item "applications" and "network".
-  * Add class Fm::CachedFolderModel, a convinient way to share Fm::FolderModel objects and reduce memory usage.
+  * Add class Fm::CachedFolderModel, a convenient way to share Fm::FolderModel objects and reduce memory usage.
   * Resize the columns of detailed list view when items are inserted or removed.
   * Optimize column widths in detailed list mode when the view is resized.
   * Only show thumbnails for the first column in detailed list mode.
@@ -909,7 +909,7 @@ libfm-qt-0.11.0 / 2016-02-27
   * Finish chown and chmod supports.
   * Try to add file opermission settings UI.
   * Implement very basic drag and drop support.
-  * Supress the incorrect default dnd handling of QListView.
+  * Suppress the incorrect default dnd handling of QListView.
   * Try to implement Dnd.
   * Finish desktop preferences.
   * Improve desktop preferences and apply settings (partially done).

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1173,7 +1173,7 @@ EXT_LINKS_IN_WINDOW = NO
 
 FORMULA_FONTSIZE = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are
 # not supported properly for IE 6.0, but are supported on all modern browsers.
 # Note that when changing this option you need to delete any form_*.png files

--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -258,7 +258,7 @@ _file_is_symlink:
     }
 
 #if 0
-    /* set "locked" icon on unaccesible folder */
+    /* set "locked" icon on unaccessible folder */
     else if(!accessible && type == G_FILE_TYPE_DIRECTORY) {
         icon = g_object_ref(icon_locked_folder);
     }

--- a/src/core/folderconfig.cpp
+++ b/src/core/folderconfig.cpp
@@ -8,7 +8,7 @@
  * This API represents access to folder-specific configuration settings.
  * Each setting is a key/value pair. To use it the descriptor should be
  * opened first, then required operations performed, then closed. Each
- * opened descriptor holds a lock on the cache so it is not adviced to
+ * opened descriptor holds a lock on the cache so it is not advised to
  * keep it somewhere.
  */
 
@@ -267,8 +267,8 @@ void FolderConfig::init(const char* globalConfigFile) {
     if(!g_key_file_load_from_file(fc_cache, globalConfigFile_.get(), G_KEY_FILE_NONE, nullptr)) {
         // fail to load the config file.
         // fallback to the legacy libfm config file for backward compatibility
-        CStrPtr legacyConfigFlie{g_build_filename(g_get_user_config_dir(), "libfm/dir-settings.conf", nullptr)};
-        g_key_file_load_from_file(fc_cache, legacyConfigFlie.get(), G_KEY_FILE_NONE, nullptr);
+        CStrPtr legacyConfigFile{g_build_filename(g_get_user_config_dir(), "libfm/dir-settings.conf", nullptr)};
+        g_key_file_load_from_file(fc_cache, legacyConfigFile.get(), G_KEY_FILE_NONE, nullptr);
     }
 }
 

--- a/src/core/iconinfo.cpp
+++ b/src/core/iconinfo.cpp
@@ -133,7 +133,7 @@ QIcon IconInfo::internalQicon() const {
     return ret_icon;
 }
 
-// compatibility function for leagcy libfm
+// compatibility function for legacy libfm
 // FIXME: deprecate this later.
 extern "C" GIcon* _fm_icon_from_name(const char* name) {
     GIcon* gicon = nullptr;

--- a/src/core/legacy/fm-config.h
+++ b/src/core/legacy/fm-config.h
@@ -114,7 +114,7 @@ typedef struct _FmConfig            FmConfig;
  * @defer_content_test: (since 1.2.0) defer test for content type on folder loading
  * @quick_exec: (since 1.2.0) don't ask user for action on executable launch
  * @modules_blacklist: (since 1.2.0) list of modules (mask in form "type:name") to never load
- * @modules_whitelist: (since 1.2.0) list of excemptions from @modules_blacklist
+ * @modules_whitelist: (since 1.2.0) list of exemptions from @modules_blacklist
  * @list_view_size_units: (since 1.2.0) file size units in list view: h, k, M, G
  * @format_cmd: (since 1.2.0) command to format the volume (device will be added)
  * @smart_desktop_autodrop: (since 1.2.0) enable "smart shortcut" auto-action for ~/Desktop

--- a/src/core/thumbnailjob.cpp
+++ b/src/core/thumbnailjob.cpp
@@ -253,7 +253,7 @@ QImage ThumbnailJob::generateThumbnail(const std::shared_ptr<const FileInfo>& fi
             && file->size() > static_cast<uint64_t>(maxExternalThumbnailFileSize_) * 1024) {
             return result;
         }
-        // try all available external thumbnailers for it until sucess
+        // try all available external thumbnailers for it until success
         int target_size = size_ > 256 ? 512 : size_ > 128 ? 256 : 128;
         file->mimeType()->forEachThumbnailer([&](const std::shared_ptr<const Thumbnailer>& thumbnailer) {
             if(thumbnailer->run(uri, thumbnailFilename.toLocal8Bit().constData(), target_size)) {

--- a/src/core/vfs/fm-xml-file.c
+++ b/src/core/vfs/fm-xml-file.c
@@ -184,7 +184,7 @@ FmXmlFile *fm_xml_file_new(FmXmlFile *sibling)
  *
  * Sets @handler for @file to be called on parse when @tag is found
  * in XML data. This function will fail if some handler for @tag was
- * aready set, in this case @error will be set appropriately.
+ * already set, in this case @error will be set appropriately.
  *
  * Returns: id for the @tag.
  *
@@ -833,7 +833,7 @@ GList *fm_xml_file_finish_parse(FmXmlFile *file, GError **error)
         {
             g_set_error_literal(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
                                 _("Document ended unexpectedly"));
-            /* FIXME: analize content of file->data to be more verbose */
+            /* FIXME: analyze content of file->data to be more verbose */
             return NULL;
         }
     }
@@ -1129,7 +1129,7 @@ gboolean fm_xml_file_item_destroy(FmXmlFileItem *item)
  * Inserts @new_item before @item that is already in XML structure. If
  * @new_item is already in the XML structure then it will be moved to
  * the new place instead.
- * Behavior after moving between defferent containers is undefined.
+ * Behavior after moving between different containers is undefined.
  *
  * Returns: %TRUE in case of success.
  *

--- a/src/core/vfs/vfs-search.c
+++ b/src/core/vfs/vfs-search.c
@@ -553,7 +553,7 @@ static void parse_search_uri(FmVfsSearchEnumerator* priv, const char* uri_str)
                     priv->mime_types = g_strsplit(value, ";", -1);
 
                     /* For mime_type patterns such as image/* and audio/*,
-                     * we move the trailing '*' to begining of the string
+                     * we move the trailing '*' to beginning of the string
                      * as a measure of optimization. Later we can detect if it's a
                      * pattern or a full type name by checking the first char. */
                     if(priv->mime_types)
@@ -859,7 +859,7 @@ static gboolean fm_search_job_match_file_type(FmVfsSearchEnumerator* priv, GFile
         {
             const char* mime_type = *pmime_type;
             /* For mime_type patterns such as image/* and audio/*,
-             * we move the trailing '*' to begining of the string
+             * we move the trailing '*' to beginning of the string
              * as a measure of optimization. We can know it's a
              * pattern not a full type name by checking the first char. */
             if(mime_type[0] == '*')

--- a/src/customactions/fileaction.cpp
+++ b/src/customactions/fileaction.cpp
@@ -40,7 +40,7 @@ bool FileActionObject::is_plural_exec(const char* exec) {
     if(!exec) {
         return false;
     }
-    // the first relevent code encountered in Exec parameter
+    // the first relevant code encountered in Exec parameter
     // determines whether the command accepts singular or plural forms
     for(int i = 0; exec[i]; ++i) {
         char ch = exec[i];
@@ -67,7 +67,7 @@ bool FileActionObject::is_plural_exec(const char* exec) {
             case 'x':
                 return false;	// singular
             default:
-                // irrelevent code, skip
+                // irrelevant code, skip
                 break;
             }
         }

--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -516,7 +516,7 @@ QString FileDialog::suffix(bool checkDefaultSuffix) const {
     if(checkDefaultSuffix && !defaultSuffix_.isEmpty()) {
         return defaultSuffix_;
     }
-    // in the save mode, still try to make a suffix out of the currrent name filter
+    // in the save mode, still try to make a suffix out of the current name filter
     if(acceptMode_ != QFileDialog::AcceptOpen) {
         auto left = currentNameFilter_.lastIndexOf(QLatin1Char('('));
         if(left != -1) {

--- a/src/filelauncher.cpp
+++ b/src/filelauncher.cpp
@@ -128,7 +128,7 @@ bool FileLauncher::showError(GAppLaunchContext* /*ctx*/, const GErrorPtr &err, c
 
 void FileLauncher::resetExecActions() {
     multiple_ = false;
-    dekstopEntryAction_ = BasicFileLauncher::ExecAction::NONE;
+    desktopEntryAction_ = BasicFileLauncher::ExecAction::NONE;
     scriptAction_ = BasicFileLauncher::ExecAction::NONE;
     execAction_ = BasicFileLauncher::ExecAction::NONE;
 }
@@ -136,8 +136,8 @@ void FileLauncher::resetExecActions() {
 BasicFileLauncher::ExecAction FileLauncher::askExecFile(const FileInfoPtr &file) {
     if(multiple_) {
         if(file->isDesktopEntry()) {
-            if(dekstopEntryAction_ != BasicFileLauncher::ExecAction::NONE) {
-                return dekstopEntryAction_;
+            if(desktopEntryAction_ != BasicFileLauncher::ExecAction::NONE) {
+                return desktopEntryAction_;
             }
         }
         else if(file->isText()) {
@@ -158,7 +158,7 @@ BasicFileLauncher::ExecAction FileLauncher::askExecFile(const FileInfoPtr &file)
     auto res = dlg.result();
     if(dlg.isRemembered()) {
         if(file->isDesktopEntry()) {
-            dekstopEntryAction_ = res;
+            desktopEntryAction_ = res;
         }
         else if(file->isText()) {
             scriptAction_ = res;

--- a/src/filelauncher.h
+++ b/src/filelauncher.h
@@ -59,7 +59,7 @@ private:
 
 private:
     bool multiple_;
-    BasicFileLauncher::ExecAction dekstopEntryAction_;
+    BasicFileLauncher::ExecAction desktopEntryAction_;
     BasicFileLauncher::ExecAction scriptAction_;
     BasicFileLauncher::ExecAction execAction_;
 };

--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -344,7 +344,7 @@ void FileMenu::addCustomActionItem(QMenu* menu, std::shared_ptr<const FileAction
         }
     }
     else if(item->is_action()) {
-        connect(action, &QAction::triggered, this, &FileMenu::onCustomActionTrigerred);
+        connect(action, &QAction::triggered, this, &FileMenu::onCustomActionTriggered);
     }
 }
 
@@ -408,7 +408,7 @@ void FileMenu::onApplicationTriggered() {
     openFilesWithApp(action->appInfo().get());
 }
 
-void FileMenu::onCustomActionTrigerred() {
+void FileMenu::onCustomActionTriggered() {
     CustomAction* action = static_cast<CustomAction*>(sender());
     auto& item = action->item();
     /* g_debug("item: %s is activated, id:%s", fm_file_action_item_get_name(item),

--- a/src/filemenu.h
+++ b/src/filemenu.h
@@ -166,7 +166,7 @@ protected Q_SLOTS:
     void onTrustToggled(bool checked);
     void onFilePropertiesTriggered();
     void onApplicationTriggered();
-    void onCustomActionTrigerred();
+    void onCustomActionTriggered();
     void onCompress();
     void onExtract();
     void onExtractHere();

--- a/src/fileoperation.h
+++ b/src/fileoperation.h
@@ -92,7 +92,7 @@ public:
         return type_;
     }
 
-    // convinient static functions
+    // convenient static functions
     static FileOperation* copyFiles(Fm::FilePathList srcFiles, Fm::FilePath dest, QWidget* parent = nullptr);
 
     static FileOperation* copyFiles(Fm::FilePathList srcFiles, Fm::FilePathList destFiles, QWidget* parent = nullptr);

--- a/src/filepropsdialog.cpp
+++ b/src/filepropsdialog.cpp
@@ -139,7 +139,7 @@ void FilePropsDialog::initPermissionsPage() {
             ownerPerm = DIFFERENT_PERMS;    // not all files have the same permission for owner
         }
         if(groupPerm != DIFFERENT_PERMS && groupPerm != (fi_mode & (S_IRGRP | S_IWGRP | S_IXGRP))) {
-            groupPerm = DIFFERENT_PERMS;    // not all files have the same permission for grop
+            groupPerm = DIFFERENT_PERMS;    // not all files have the same permission for group
         }
         if(otherPerm != DIFFERENT_PERMS && otherPerm != (fi_mode & (S_IROTH | S_IWOTH | S_IXOTH))) {
             otherPerm = DIFFERENT_PERMS;    // not all files have the same permission for other
@@ -675,13 +675,13 @@ void FilePropsDialog::accept() {
     // Custom (folder) icon
     if(!customIcon.isNull()) {
         bool reloadNeeded(false);
-        QString iconNamne = customIcon.name();
+        QString iconName = customIcon.name();
         for(auto& fi: fileInfos_) {
             std::shared_ptr<const Fm::IconInfo> icon = fi->icon();
-            if (!fi->icon() || fi->icon()->qicon().name() != iconNamne) {
+            if (!fi->icon() || fi->icon()->qicon().name() != iconName) {
                 auto dot_dir = CStrPtr{g_build_filename(fi->path().localPath().get(), ".directory", nullptr)};
                 GKeyFile* kf = g_key_file_new();
-                g_key_file_set_string(kf, "Desktop Entry", "Icon", iconNamne.toLocal8Bit().constData());
+                g_key_file_set_string(kf, "Desktop Entry", "Icon", iconName.toLocal8Bit().constData());
                 Fm::GErrorPtr err;
                 if (!g_key_file_save_to_file(kf, dot_dir.get(), &err)) {
                     QMessageBox::critical(this, QObject::tr("Custom Icon Error"), err.message());
@@ -709,25 +709,25 @@ void FilePropsDialog::accept() {
     }
 
     // Emblem icon
-    QString iconNamne;
+    QString iconName;
     if(ui->emblemButton->toolButtonStyle() == Qt::ToolButtonTextBesideIcon
        && !ui->emblemButton->icon().isNull()) { // emblem is set
-        iconNamne = ui->emblemButton->icon().name();
+        iconName = ui->emblemButton->icon().name();
     }
     if(ui->emblemButton->toolButtonStyle() == Qt::ToolButtonTextOnly // emblem is removed
-       || !iconNamne.isEmpty()) { // emblem is set
+       || !iconName.isEmpty()) { // emblem is set
 
         // NOTE: If a folder and its parent are both open (e.g., in different tabs),
-        // we sould set the emblem for two file infos corresponding to the current path;
+        // we should set the emblem for two file infos corresponding to the current path;
         // otherwise, the emblem state will not be updated everywhere without reloading.
 
         for(auto& fi: fileInfos_) {
-            fi->setEmblem(iconNamne);
+            fi->setEmblem(iconName);
             if(fi->isDir()) {
                 auto folder = Fm::Folder::findByPath(fi->path());
                 if(folder != nullptr && folder->isValid() // the folder itself is open
                    && folder->info() != fi) {
-                    folder->info()->setEmblem(iconNamne, false);
+                    folder->info()->setEmblem(iconName, false);
                 }
             }
         }
@@ -739,7 +739,7 @@ void FilePropsDialog::accept() {
                 for(auto& file: files) {
                     if(file->path() == path) {
                         if(file != fileInfo) { // an empty space inside the folder was right clicked
-                            file->setEmblem(iconNamne, false);
+                            file->setEmblem(iconName, false);
                         }
                         break;
                     }

--- a/src/filepropsdialog.h
+++ b/src/filepropsdialog.h
@@ -77,7 +77,7 @@ private:
     bool singleFile; // only one file is selected?
     bool hasDir; // is there any dir in the files?
     bool allNative; // all files are on native UNIX filesystems (not virtual or remote)
-    QIcon customIcon; // custom (folder) icon (wiil be checked for its nullity)
+    QIcon customIcon; // custom (folder) icon (will be checked for its nullity)
 
     std::shared_ptr<const Fm::MimeType> mimeType; // mime type of the files
 

--- a/src/foldermenu.cpp
+++ b/src/foldermenu.cpp
@@ -164,11 +164,11 @@ void FolderMenu::addCustomActionItem(QMenu* menu, std::shared_ptr<const FileActi
         }
     }
     else if(item->is_action()) {
-        connect(action, &QAction::triggered, this, &FolderMenu::onCustomActionTrigerred);
+        connect(action, &QAction::triggered, this, &FolderMenu::onCustomActionTriggered);
     }
 }
 
-void FolderMenu::onCustomActionTrigerred() {
+void FolderMenu::onCustomActionTriggered() {
     CustomAction* action = static_cast<CustomAction*>(sender());
     auto& item = action->item();
     auto folderInfo = view_->folderInfo();

--- a/src/foldermenu.h
+++ b/src/foldermenu.h
@@ -101,7 +101,7 @@ protected Q_SLOTS:
     void onFolderFirstActionTriggered(bool checked);
     void onHiddenLastActionTriggered(bool checked);
     void onPropertiesActionTriggered();
-    void onCustomActionTrigerred();
+    void onCustomActionTriggered();
 
 private:
     void createSortMenu();

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -217,7 +217,7 @@ QModelIndex FolderViewListView::indexAt(const QPoint& point) const {
 
 // NOTE:
 // QListView has a problem which I consider a bug or a design flaw.
-// When you set movement property to Static, theoratically the icons
+// When you set movement property to Static, theoretically the icons
 // should not be movable. However, if you turned on icon mode,
 // the icons becomes freely movable despite the value of movement is Static.
 // To overcome this bug, we override all drag handling methods, and
@@ -617,7 +617,7 @@ void FolderViewTreeView::dropEvent(QDropEvent* e) {
 
 // the default list mode of QListView handles column widths
 // very badly (worse than gtk+) and it's not very flexible.
-// so, let's handle column widths outselves.
+// so, let's handle column widths ourselves.
 void FolderViewTreeView::layoutColumns() {
     // qDebug("layoutColumns");
     if(!model()) {
@@ -716,7 +716,7 @@ void FolderViewTreeView::layoutColumns() {
         }
 
         if(customColumnWidths_.size() <= filenameColumn) { // practically means no custom width
-            // if the total witdh we want exceeds the available space
+            // if the total width we want exceeds the available space
             if(desiredWidth > availWidth) {
                 // Compute the width available for the filename column
                 int filenameAvailWidth = availWidth - desiredWidth + widths.at(filenameColumn);

--- a/src/mountoperation.h
+++ b/src/mountoperation.h
@@ -38,7 +38,7 @@ namespace Fm {
 // Need to find a better API design which make things fully async and cancellable.
 
 // FIXME: parent_ does not work. All dialogs shown by the mount operation has no parent window assigned.
-// FIXME: Need to reconsider the propery way of API design. Blocking sync calls are handy, but
+// FIXME: Need to reconsider the proper way of API design. Blocking sync calls are handy, but
 // indeed causes some problems. :-(
 
 class LIBFM_QT_API MountOperation: public QObject {

--- a/src/pathbar.cpp
+++ b/src/pathbar.cpp
@@ -186,7 +186,7 @@ void PathBar::onButtonToggled(bool checked) {
         currentPath_ = pathForButton(btn);
         Q_EMIT chdir(currentPath_);
 
-        // since scrolling to the toggled buton will happen correctly only when the
+        // since scrolling to the toggled button will happen correctly only when the
         // layout is updated and because the update is disabled on creating buttons
         // in setPath(), the update status can be used as a sign to know when to wait
         if(updatesEnabled()) {

--- a/src/placesmodel.cpp
+++ b/src/placesmodel.cpp
@@ -61,9 +61,9 @@ PlacesModel::PlacesModel(QObject* parent):
     placesRoot->appendRow(computerItem);
 
     { // Applications
-        const char* applicaion_icon_names[] = {"system-software-install", "applications-accessories", "application-x-executable"};
+        const char* application_icon_names[] = {"system-software-install", "applications-accessories", "application-x-executable"};
         // NOTE: g_themed_icon_new_from_names() accepts char**, but actually const char** is OK.
-        Fm::GIconPtr gicon{g_themed_icon_new_from_names((char**)applicaion_icon_names, G_N_ELEMENTS(applicaion_icon_names)), false};
+        Fm::GIconPtr gicon{g_themed_icon_new_from_names((char**)application_icon_names, G_N_ELEMENTS(application_icon_names)), false};
         auto fmicon = Fm::IconInfo::fromGIcon(std::move(gicon));
         applicationsItem = new PlacesModelItem(fmicon, tr("Applications"), Fm::FilePath::fromUri("menu:///applications/"));
         placesRoot->appendRow(applicationsItem);
@@ -493,7 +493,7 @@ void PlacesModel::onBookmarksChanged() {
 
 Qt::ItemFlags PlacesModel::flags(const QModelIndex& index) const {
     if(!index.isValid()) {
-       // alow dropping on empty space (but also see PlacesModel::canDropMimeData)
+       // allow dropping on empty space (but also see PlacesModel::canDropMimeData)
        return Qt::ItemIsDropEnabled;
     }
     if(index.column() == 1) { // make 2nd column of every row selectable.

--- a/src/placesview.cpp
+++ b/src/placesview.cpp
@@ -331,7 +331,7 @@ void PlacesView::dragMoveEvent(QDragMoveEvent* event) {
 void PlacesView::dropEvent(QDropEvent* event) {
     // NOTE: Under Wayland, serious problems will happen if the DND menu is shown
     // while the DND is in progress. Also, the menu needs a parent for correct positioning.
-    if(!event->mimeData()->hasFormat(QStringLiteral("application/x-bookmark-row")) // droppped data is not a bookmark row
+    if(!event->mimeData()->hasFormat(QStringLiteral("application/x-bookmark-row")) // dropped data is not a bookmark row
        && event->mimeData()->hasUrls()) { // file uris are dropped
         QModelIndex index = indexAt(event->pos());
         if(index.isValid()

--- a/src/proxyfoldermodel.cpp
+++ b/src/proxyfoldermodel.cpp
@@ -270,7 +270,7 @@ void ProxyFolderModel::setShowThumbnails(bool show) {
                 connect(srcModel, &FolderModel::thumbnailLoaded, this, &ProxyFolderModel::onThumbnailLoaded);
             }
             else { // turn off thumbnails
-                // free cached old thumbnails in souce model
+                // free cached old thumbnails in source model
                 srcModel->releaseThumbnails(thumbnailSize_);
                 disconnect(srcModel, &FolderModel::thumbnailLoaded, this, &ProxyFolderModel::onThumbnailLoaded);
             }


### PR DESCRIPTION
Typo fixes to comments/text and identifiers.

Affected files:
- CHANGELOG
- Doxyfile.in
- src/core/fileinfo.cpp
- src/core/folderconfig.cpp
- src/core/iconinfo.cpp
- src/core/legacy/fm-config.h
- src/core/thumbnailjob.cpp
- src/core/vfs/fm-xml-file.c
- src/core/vfs/vfs-search.c
- src/customactions/fileaction.cpp
- src/filedialog.cpp
- src/filelauncher.cpp
- src/filelauncher.h
- src/filemenu.cpp
- src/filemenu.h
- src/fileoperation.h
- src/filepropsdialog.cpp
- src/filepropsdialog.h
- src/foldermenu.cpp
- src/foldermenu.h
- src/folderview.cpp
- src/mountoperation.h
- src/pathbar.cpp
- src/placesmodel.cpp
- src/placesview.cpp
- src/proxyfoldermodel.cpp
