### PR TITLE
Ensure `Escape` closes the popup of path-edit completer

### DIFF
--- a/src/pathedit.cpp
+++ b/src/pathedit.cpp
@@ -148,6 +148,14 @@ bool PathEdit::event(QEvent* e) {
             return true;
         }
     }
+    else if(e->type() == QEvent::ShortcutOverride && completer_->popup()->isVisible()) {
+        // If the popup is visible, ensure that it will be closed by pressing "Escape".
+        QKeyEvent* keyEvent = static_cast<QKeyEvent*>(e);
+        if(keyEvent->key() == Qt::Key_Escape && keyEvent->modifiers() == Qt::NoModifier) {
+            e->accept();
+            return true;
+        }
+    }
     return QLineEdit::event(e);
 }
 


### PR DESCRIPTION
Since `Escape` may be registered as a shortcut elsewhere, the code should override the shortcut when needed.

Fixes https://github.com/lxqt/pcmanfm-qt/issues/1740