### PR TITLE
Add Name=  and Type=  keys for File Properties .directory files

### DIFF
--- a/src/filepropsdialog.cpp
+++ b/src/filepropsdialog.cpp
@@ -681,6 +681,8 @@ void FilePropsDialog::accept() {
             if (!fi->icon() || fi->icon()->qicon().name() != iconName) {
                 auto dot_dir = CStrPtr{g_build_filename(fi->path().localPath().get(), ".directory", nullptr)};
                 GKeyFile* kf = g_key_file_new();
+                // g_key_file_set_string(kf, "Desktop Entry", "Name", ...);
+                g_key_file_set_string(kf, "Desktop Entry", "Type", "Directory");
                 g_key_file_set_string(kf, "Desktop Entry", "Icon", iconName.toLocal8Bit().constData());
                 Fm::GErrorPtr err;
                 if (!g_key_file_save_to_file(kf, dot_dir.get(), &err)) {


### PR DESCRIPTION
According to the XDG Desktop Entry Specification, `Name=` and `Type=` are required desktop entry keys (including for `.directory` files):
https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys

This PR adds a `Type=Directory` key for `.directory` files generated when changing the folder icon with 'File Properties'. Pending any comments on what `Name=` should be, that should be added as well.
