### PR TITLE
Use "New file" as the default name for new files

### DIFF
--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -229,7 +229,7 @@ void createFileOrFolder(CreateFileType type, FilePath parentDir, const TemplateI
     switch(type) {
     case CreateNewTextFile:
         prompt = QObject::tr("Please enter a new file name:");
-        defaultNewName = QObject::tr("New text file");
+        defaultNewName = QObject::tr("New file");
         break;
 
     case CreateNewFolder:


### PR DESCRIPTION
Because it isn't `text/plain` after GLib 2.75.1.

It's more consistent with "New folder" too.