### PR TITLE
Ensure toolbar background is shown behind path-bar

### DIFF
--- a/src/pathbar.cpp
+++ b/src/pathbar.cpp
@@ -81,6 +81,10 @@ PathBar::PathBar(QWidget* parent):
     buttonsLayout_->setSpacing(0);
     buttonsLayout_->setSizeConstraint(QLayout::SetFixedSize); // required when added to scroll area according to QScrollArea doc.
     scrollArea_->setWidget(buttonsWidget_); // make the buttons widget scrollable if the path is too long
+
+    // ensure the parent's background is shown behind the bar
+    scrollArea_->viewport()->setAutoFillBackground(false);
+    buttonsWidget_->setAutoFillBackground(false);
 }
 
 void PathBar::resizeEvent(QResizeEvent* event) {


### PR DESCRIPTION
Some Qt styles may fill the path-bar with the button color. This patch removes the auto-filling.

Related to https://github.com/lxqt/pcmanfm-qt/issues/1755