### PR TITLE
Prevent long content search texts from widening search dialog

### DIFF
--- a/src/filesearchdialog.cpp
+++ b/src/filesearchdialog.cpp
@@ -48,6 +48,11 @@ FileSearchDialog::FileSearchDialog(QStringList paths, QWidget* parent, Qt::Windo
     ui->namePatterns->completer()->setCaseSensitivity(Qt::CaseSensitive);
     ui->contentPattern->completer()->setCaseSensitivity(Qt::CaseSensitive);
 
+    // if the minimum width is not set here, it will be set by the item model,
+    // which can contain long texts and make the window very wide
+    ui->namePatterns->setMinimumWidth(150);
+    ui->contentPattern->setMinimumWidth(150);
+
     ui->namePatterns->setFocus();
 }
 


### PR DESCRIPTION
Previously, if the search history was enabled, long content search texts could widen the search dialog the next time it was shown. If the user entered a very long content search text (by mistake), the search dialog might become unusable the next time.

This is an old issue in Qt and also exists in Qt6. The patch circumvents it by setting the minimum widths of the search boxes.