### PR TITLE
Dialog window icons for Create New folder/blank file

### DIFF
--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -228,16 +228,19 @@ void createFileOrFolder(CreateFileType type, FilePath parentDir, const TemplateI
 
     switch(type) {
     case CreateNewTextFile:
+        parent->setWindowIcon(QIcon::fromTheme(QStringLiteral("document-new")));
         prompt = QObject::tr("Please enter a new file name:");
         defaultNewName = QObject::tr("New file");
         break;
 
     case CreateNewFolder:
+        parent->setWindowIcon(QIcon::fromTheme(QStringLiteral("folder-new")));
         prompt = QObject::tr("Please enter a new folder name:");
         defaultNewName = QObject::tr("New folder");
         break;
 
     case CreateWithTemplate: {
+        parent->setWindowIcon(QIcon());
         auto mime = templ->mimeType();
         prompt = QObject::tr("Enter a name for the new %1:").arg(QString::fromUtf8(mime->desc()));
         defaultNewName = QString::fromStdString(templ->name());


### PR DESCRIPTION
Add window icons to the dialogs of Create New → Folder, and Create New → Blank File.

Create New  → \<template\> dialog icons are unchanged (as there seemingly isn't an appropriate icon).