### PR TITLE
Prevent invisible "Create New" dialog under Wayland

### DIFF
--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -276,7 +276,7 @@ _retry:
         layout->addWidget(le);
         layout->addWidget(btns);
         dlg.setLayout(layout);
-        dlg.setMaximumHeight(dlg.minimumHeight()); // no vertical resizing
+        dlg.setMaximumHeight(dlg.minimumSizeHint().height()); // no vertical resizing
 
         switch (dlg.exec()) {
         case QDialog::Accepted:


### PR DESCRIPTION
Under Wayland and with Qt6, `QWidget::minimumHeight()` is zero for a dialog before it's shown. It's better to be cautious with Qt5 too.