### PR TITLE
File dialog: Also add suffixes containing dot on saving

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -542,7 +542,7 @@ QString FileDialog::suffix(bool checkDefaultSuffix) const {
                 left = suffix.indexOf(QLatin1Char('.')); // it can be like ".tar.xz"
                 if(left != -1 && suffix.size() - left > 1) {
                     suffix = suffix.right(suffix.size() - left - 1);
-                    if(suffix.indexOf(QRegularExpression(QStringLiteral("\\W"))) == -1) {
+                    if(suffix.indexOf(QRegularExpression(QStringLiteral("[^\\w\\.]"))) == -1) {
                         return suffix;
                     }
                 }


### PR DESCRIPTION
This patch changes a too strong condition which was used in https://github.com/lxqt/libfm-qt/commit/6575eff8ac65ddc7c82005b044f80284e449bd03 to fix a problem. With `\W` in that commit, good extensions like `.tar.gz` weren't added automatically on saving.