### PR TITLE
Remember password and anonymity settings of mount dialog

### DIFF
--- a/src/mount-operation-password.ui
+++ b/src/mount-operation-password.ui
@@ -133,6 +133,9 @@
    </item>
    <item>
     <widget class="QRadioButton" name="sessionPassword">
+     <property name="toolTip">
+      <string>Session length is determined by password manager</string>
+     </property>
      <property name="text">
       <string>Remember password for &amp;this session</string>
      </property>


### PR DESCRIPTION
… if they are relevant.

Also, a tooltip is added about the session length.

NOTE: I'll apply the patch to the Qt6 branch after this is merged.