### PR TITLE
Add splitIndex parameter to FileLauncher methods

### DIFF
--- a/src/core/basicfilelauncher.cpp
+++ b/src/core/basicfilelauncher.cpp
@@ -23,7 +23,7 @@ BasicFileLauncher::BasicFileLauncher():
 BasicFileLauncher::~BasicFileLauncher() {
 }
 
-bool BasicFileLauncher::launchFiles(const FileInfoList& fileInfos, GAppLaunchContext* ctx) {
+bool BasicFileLauncher::internalLaunchFiles(const FileInfoList& fileInfos, GAppLaunchContext* ctx, size_t splitIndex) {
     FileInfoList mimeTypeInfos;
     FileInfoList folderInfos;
     FilePathList pathsToLaunch;
@@ -79,7 +79,7 @@ bool BasicFileLauncher::launchFiles(const FileInfoList& fileInfos, GAppLaunchCon
     // open folders
     if(!folderInfos.empty()) {
         GErrorPtr err;
-        openFolder(ctx, folderInfos, err);
+        openFolder(ctx, folderInfos, splitIndex, err);
     }
 
     // Open files of different mime-types with their default apps,
@@ -146,7 +146,7 @@ bool BasicFileLauncher::launchFiles(const FileInfoList& fileInfos, GAppLaunchCon
     return true;
 }
 
-bool BasicFileLauncher::launchPaths(FilePathList paths, GAppLaunchContext* ctx) {
+bool BasicFileLauncher::launchPaths(FilePathList paths,  GAppLaunchContext* ctx, size_t splitIndex) {
     // FIXME: blocking with an event loop is not a good design :-(
     QEventLoop eventLoop;
     auto job = new FileInfoJob{paths};
@@ -177,7 +177,7 @@ bool BasicFileLauncher::launchPaths(FilePathList paths, GAppLaunchContext* ctx) 
     eventLoop.exec();
 
     // launch the file info
-    launchFiles(job->files(), ctx);
+    internalLaunchFiles(job->files(), ctx, splitIndex);
 
     delete job;
     return false;
@@ -187,7 +187,7 @@ GAppInfoPtr BasicFileLauncher::chooseApp(const FileInfoList& /* fileInfos */, co
     return GAppInfoPtr{};
 }
 
-bool BasicFileLauncher::openFolder(GAppLaunchContext* ctx, const FileInfoList& folderInfos, GErrorPtr& err) {
+bool BasicFileLauncher::openFolder(GAppLaunchContext* ctx, const FileInfoList& folderInfos, size_t /* splitIndex */, GErrorPtr& err) {
     auto app = chooseApp(folderInfos, "inode/directory", err);
     if(app) {
         launchWithApp(app.get(), folderInfos.paths(), ctx);

--- a/src/core/basicfilelauncher.h
+++ b/src/core/basicfilelauncher.h
@@ -25,9 +25,11 @@ public:
     explicit BasicFileLauncher();
     virtual ~BasicFileLauncher();
 
-    bool launchFiles(const FileInfoList &fileInfos, GAppLaunchContext* ctx = nullptr);
+    bool launchFiles(const FileInfoList &fileInfos, GAppLaunchContext* ctx = nullptr) {
+        return internalLaunchFiles(fileInfos, ctx, 0);
+    }
 
-    bool launchPaths(FilePathList paths, GAppLaunchContext* ctx = nullptr);
+    bool launchPaths(FilePathList paths, GAppLaunchContext* ctx = nullptr, size_t splitIdx = 0);
 
     bool launchDesktopEntry(const FileInfoPtr &fileInfo, const FilePathList& paths = FilePathList{}, GAppLaunchContext* ctx = nullptr);
 
@@ -51,7 +53,7 @@ protected:
 
     virtual GAppInfoPtr chooseApp(const FileInfoList& fileInfos, const char* mimeType, GErrorPtr& err);
 
-    virtual bool openFolder(GAppLaunchContext* ctx, const FileInfoList& folderInfos, GErrorPtr& err);
+    virtual bool openFolder(GAppLaunchContext* ctx, const FileInfoList& folderInfos, size_t splitIndex, GErrorPtr& err);
 
     virtual bool showError(GAppLaunchContext* ctx, const GErrorPtr& err, const FilePath& path = FilePath{}, const FileInfoPtr& info = FileInfoPtr{});
 
@@ -62,6 +64,8 @@ protected:
 private:
 
     FilePath handleShortcut(const FileInfoPtr &fileInfo, GAppLaunchContext* ctx = nullptr);
+
+    bool internalLaunchFiles(const FileInfoList &fileInfos, GAppLaunchContext* ctx, size_t splitIndex);
 
 private:
     bool quickExec_; // Don't ask options on launch executable file

--- a/src/filelauncher.cpp
+++ b/src/filelauncher.cpp
@@ -48,11 +48,11 @@ bool FileLauncher::launchFiles(QWidget* parent, const FileInfoList &file_infos) 
     return ret;
 }
 
-bool FileLauncher::launchPaths(QWidget* parent, const FilePathList& paths) {
+bool FileLauncher::launchPaths(QWidget* parent, const FilePathList& paths, size_t splitIndex) {
     resetExecActions();
     multiple_ = paths.size() > 1;
     GObjectPtr<FmAppLaunchContext> context{fm_app_launch_context_new_for_widget(parent), false};
-    bool ret = BasicFileLauncher::launchPaths(paths, G_APP_LAUNCH_CONTEXT(context.get()));
+    bool ret = BasicFileLauncher::launchPaths(paths, G_APP_LAUNCH_CONTEXT(context.get()), splitIndex);
     launchedPaths(paths);
     return ret;
 }
@@ -92,8 +92,8 @@ GAppInfoPtr FileLauncher::chooseApp(const FileInfoList& /*fileInfos*/, const cha
     return app;
 }
 
-bool FileLauncher::openFolder(GAppLaunchContext *ctx, const FileInfoList &folderInfos, GErrorPtr &err) {
-    return BasicFileLauncher::openFolder(ctx, folderInfos, err);
+bool FileLauncher::openFolder(GAppLaunchContext *ctx, const FileInfoList &folderInfos, size_t splitIndex, GErrorPtr &err) {
+    return BasicFileLauncher::openFolder(ctx, folderInfos, splitIndex, err);
 }
 
 bool FileLauncher::showError(GAppLaunchContext* /*ctx*/, const GErrorPtr &err, const FilePath &path, const FileInfoPtr &info) {

--- a/src/filelauncher.h
+++ b/src/filelauncher.h
@@ -35,7 +35,7 @@ public:
 
     bool launchFiles(QWidget* parent, const FileInfoList& file_infos);
 
-    bool launchPaths(QWidget* parent, const FilePathList &paths);
+    bool launchPaths(QWidget* parent, const FilePathList &paths, size_t splitIndex = 0);
 
     bool launchWithApp(QWidget* parent, GAppInfo* app, const FilePathList& paths);
 
@@ -43,7 +43,7 @@ protected:
 
     GAppInfoPtr chooseApp(const FileInfoList& fileInfos, const char* mimeType, GErrorPtr& err) override;
 
-    bool openFolder(GAppLaunchContext* ctx, const FileInfoList& folderInfos, GErrorPtr& err) override;
+    bool openFolder(GAppLaunchContext* ctx, const FileInfoList& folderInfos, size_t splitIndex, GErrorPtr& err) override;
 
     bool showError(GAppLaunchContext* ctx, const GErrorPtr &err, const FilePath& path = FilePath{}, const FileInfoPtr& info = FileInfoPtr{}) override;
 


### PR DESCRIPTION
Add splitIndex parameter to some methods on BasicFileLauncher and FileLauncher.

Allows fixing https://github.com/lxqt/pcmanfm-qt/issues/1329.

See also https://github.com/lxqt/pcmanfm-qt/pull/1806.