### PR TITLE
add foot to terminals.list

### DIFF
--- a/data/terminals.list
+++ b/data/terminals.list
@@ -87,3 +87,7 @@ open_arg=-e
 open_arg=-e
 noclose_arg=--hold -e
 desktop_id=Alacritty.desktop
+
+[foot]
+noclose_arg=--hold
+desktop_id=org.codeberg.dnkl.foot.desktop


### PR DESCRIPTION
only tested on artix linux (with the arch linux package) in pcmanfm-qt but i'm guessing this should work just about everywhere since it's a simple change