### PR TITLE
Add "Copy Location" context menu action

### DIFF
--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -61,6 +61,7 @@ FileMenu::FileMenu(Fm::FileInfoList files, std::shared_ptr<const Fm::FileInfo> i
     separator1_ = nullptr;
     cutAction_ = nullptr;
     copyAction_ = nullptr;
+    copyLocationAction_ = nullptr;
     pasteAction_ = nullptr;
     deleteAction_ = nullptr;
     unTrashAction_ = nullptr;
@@ -159,6 +160,10 @@ FileMenu::FileMenu(Fm::FileInfoList files, std::shared_ptr<const Fm::FileInfo> i
         connect(copyAction_, &QAction::triggered, this, &FileMenu::onCopyTriggered);
         addAction(copyAction_);
 
+        copyLocationAction_ = new QAction(QIcon::fromTheme(QStringLiteral("edit-copy-path")), tr("Copy Location"), this);
+        connect(copyLocationAction_, &QAction::triggered, this, &FileMenu::onCopyLocationTriggered);
+        addAction(copyLocationAction_);
+
         pasteAction_ = new QAction(QIcon::fromTheme(QStringLiteral("edit-paste")), tr("Paste"), this);
         connect(pasteAction_, &QAction::triggered, this, &FileMenu::onPasteTriggered);
         addAction(pasteAction_);
@@ -190,6 +195,10 @@ FileMenu::FileMenu(Fm::FileInfoList files, std::shared_ptr<const Fm::FileInfo> i
             }
         }
         copyAction_->setEnabled(hasAccessible);
+
+        //If only one item selected, offer to copy its path
+        copyLocationAction_->setEnabled(hasAccessible && files_.size() == 1);
+
         cutAction_->setEnabled(hasDeletable);
         deleteAction_->setEnabled(hasDeletable);
         renameAction_->setEnabled(hasRenamable);
@@ -432,6 +441,10 @@ void FileMenu::onFilePropertiesTriggered() {
 
 void FileMenu::onCopyTriggered() {
     Fm::copyFilesToClipboard(files_.paths());
+}
+
+void FileMenu::onCopyLocationTriggered() {
+    Fm::copyFilePathToClipboard(files_.at(0)->path());
 }
 
 void FileMenu::onCutTriggered() {

--- a/src/filemenu.h
+++ b/src/filemenu.h
@@ -88,6 +88,10 @@ public:
         return copyAction_;
     }
 
+    QAction* copyPathAction() {
+        return copyLocationAction_;
+    }
+
     QAction* pasteAction() {
         return pasteAction_;
     }
@@ -173,6 +177,7 @@ protected Q_SLOTS:
 
     void onCutTriggered();
     void onCopyTriggered();
+    void onCopyLocationTriggered();
     void onPasteTriggered();
     void onRenameTriggered();
     void onDeleteTriggered();
@@ -199,6 +204,7 @@ private:
     QAction* separator2_;
     QAction* cutAction_;
     QAction* copyAction_;
+    QAction* copyLocationAction_;
     QAction* pasteAction_;
     QAction* deleteAction_;
     QAction* unTrashAction_;

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -127,6 +127,18 @@ void copyFilesToClipboard(const Fm::FilePathList& files) {
     clipboard->setMimeData(data);
 }
 
+void copyFilePathToClipboard(const FilePath &file) {
+    QClipboard* clipboard = QApplication::clipboard();
+    QMimeData* data = new QMimeData();
+
+    QString path = QString::fromUtf8(file.localPath().get());
+    if(path.isEmpty())
+        path = QString::fromUtf8(file.uri().get());
+
+    data->setText(path);
+    clipboard->setMimeData(data);
+}
+
 void cutFilesToClipboard(const Fm::FilePathList& files) {
     QClipboard* clipboard = QApplication::clipboard();
     QMimeData* data = new QMimeData();

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -47,6 +47,8 @@ LIBFM_QT_API void pasteFilesFromClipboard(const Fm::FilePath& destPath, QWidget*
 
 LIBFM_QT_API void copyFilesToClipboard(const Fm::FilePathList& files);
 
+LIBFM_QT_API void copyFilePathToClipboard(const Fm::FilePath& file);
+
 LIBFM_QT_API void cutFilesToClipboard(const Fm::FilePathList& files);
 
 LIBFM_QT_API bool changeFileName(const Fm::FilePath& path, const QString& newName, QWidget* parent, bool showMessage = true);


### PR DESCRIPTION
Hello,
I've made a small patch which adds "Copy Location" to file context menu when only one item is selected.
I find it super useful when using terminal a lot, to paste file path in the command line.
Previously when copying files and pasting them inside terminal, it would paste an URI beginning with `file:///` which would break command line tools expecting a normal file path and thus has to be manually removed.

If `edit-copy-path` icon is not present, it automatically falls back to `edit-copy` icon.