### PR TITLE
Add 4 menu icons (file menu, folder menu)

### DIFF
--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -251,7 +251,7 @@ FileMenu::FileMenu(Fm::FileInfoList files, std::shared_ptr<const Fm::FileInfo> i
             if(!mountSeparator) {
                 addSeparator();
             }
-            QAction* action = new QAction(tr("Eject"), this);
+            QAction* action = new QAction(QIcon::fromTheme(QStringLiteral("media-eject")), tr("Eject"), this);
             connect(action, &QAction::triggered, this, [this] {
                 if(info_->canEject()) {
                     MountOperation* op = new MountOperation(true, parentWidget());

--- a/src/foldermenu.cpp
+++ b/src/foldermenu.cpp
@@ -217,12 +217,12 @@ void FolderMenu::createSortMenu() {
 
     QActionGroup* group = new QActionGroup(this);
     group->setExclusive(true);
-    actionAscending_ = new QAction(tr("Ascending"), this);
+    actionAscending_ = new QAction(QIcon::fromTheme(QStringLiteral("view-sort-ascending")), tr("Ascending"), this);
     actionAscending_->setCheckable(true);
     sortMenu_->addAction(actionAscending_);
     group->addAction(actionAscending_);
 
-    actionDescending_ = new QAction(tr("Descending"), this);
+    actionDescending_ = new QAction(QIcon::fromTheme(QStringLiteral("view-sort-descending")), tr("Descending"), this);
     actionDescending_->setCheckable(true);
     sortMenu_->addAction(actionDescending_);
     group->addAction(actionDescending_);

--- a/src/foldermenu.cpp
+++ b/src/foldermenu.cpp
@@ -84,7 +84,7 @@ FolderMenu::FolderMenu(FolderView* view, QWidget* parent):
         separator3_ = nullptr;
     }
     else {
-        selectAllAction_ = new QAction(tr("Select &All"), this);
+        selectAllAction_ = new QAction(QIcon::fromTheme(QStringLiteral("edit-select-all")), tr("Select &All"), this);
         addAction(selectAllAction_);
         connect(selectAllAction_, &QAction::triggered, this, &FolderMenu::onSelectAllActionTriggered);
 


### PR DESCRIPTION
Add 4 icons to context menus: namely 'media-eject', 'edit-select-all', 'view-sort-ascending', 'view-sort-descending'.

The icons exist in well-known icon sets; the Adwaita icon set has them but in "-symbolic" form.