### PR TITLE
Reorder XML .ui files to correct tab orders

### DIFF
--- a/src/app-chooser-dialog.ui
+++ b/src/app-chooser-dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>432</width>
-    <height>447</height>
+    <height>387</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/app-chooser-dialog.ui
+++ b/src/app-chooser-dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>432</width>
-    <height>387</height>
+    <height>447</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -56,16 +56,6 @@
        <item row="1" column="0" colspan="2">
         <widget class="QLineEdit" name="cmdLine"/>
        </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_4">
-         <property name="text">
-          <string>Application name:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QLineEdit" name="appName"/>
-       </item>
        <item row="2" column="0" colspan="2">
         <widget class="QLabel" name="label_5">
          <property name="text">
@@ -82,6 +72,23 @@
          </property>
         </widget>
        </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Application name:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLineEdit" name="appName"/>
+       </item>
+       <item row="4" column="0" colspan="2">
+        <widget class="QCheckBox" name="useTerminal">
+         <property name="text">
+          <string>Execute in terminal emulator</string>
+         </property>
+        </widget>
+       </item>
        <item row="5" column="0" colspan="2">
         <widget class="QCheckBox" name="keepTermOpen">
          <property name="enabled">
@@ -89,13 +96,6 @@
          </property>
          <property name="text">
           <string>Keep terminal window open after command execution</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0" colspan="2">
-        <widget class="QCheckBox" name="useTerminal">
-         <property name="text">
-          <string>Execute in terminal emulator</string>
          </property>
         </widget>
        </item>

--- a/src/edit-bookmarks.ui
+++ b/src/edit-bookmarks.ui
@@ -14,6 +14,13 @@
    <string>Edit Bookmarks</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Use drag and drop to reorder the items</string>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="0">
     <widget class="QTreeWidget" name="treeWidget">
      <property name="acceptDrops">
@@ -95,13 +102,6 @@
       </spacer>
      </item>
     </layout>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Use drag and drop to reorder the items</string>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/src/file-operation-dialog.ui
+++ b/src/file-operation-dialog.ui
@@ -26,6 +26,16 @@
      <property name="fieldGrowthPolicy">
       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
      </property>
+     <item row="0" column="0" colspan="2">
+      <widget class="QListWidget" name="sourceFiles">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
      <item row="1" column="0">
       <widget class="QLabel" name="destLabel">
        <property name="text">
@@ -83,6 +93,20 @@
        </property>
       </widget>
      </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Files processed:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLabel" name="filesProcessed">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
      <item row="5" column="0">
       <widget class="QLabel" name="label_5">
        <property name="sizePolicy">
@@ -104,30 +128,6 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0" colspan="2">
-      <widget class="QListWidget" name="sourceFiles">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_6">
-       <property name="text">
-        <string>Files processed:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QLabel" name="filesProcessed">
        <property name="text">
         <string/>
        </property>

--- a/src/file-props.ui
+++ b/src/file-props.ui
@@ -100,6 +100,32 @@
          </property>
         </widget>
        </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="targetLabel">
+         <property name="text">
+          <string>Link target:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLabel" name="target">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
        <item row="3" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
@@ -143,6 +169,23 @@
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="openWithLabel">
+         <property name="text">
+          <string>Open With:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="Fm::AppChooserComboBox" name="openWith">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
         </widget>
        </item>
@@ -212,49 +255,6 @@
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="targetLabel">
-         <property name="text">
-          <string>Link target:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QLabel" name="target">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="openWithLabel">
-         <property name="text">
-          <string>Open With:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="Fm::AppChooserComboBox" name="openWith">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
          </property>
         </widget>
        </item>
@@ -391,6 +391,13 @@
          <property name="verticalSpacing">
           <number>5</number>
          </property>
+         <item row="0" column="0" rowspan="2" alignment="Qt::AlignVCenter">
+          <widget class="QLabel" name="deviceLabel">
+           <property name="text">
+            <string>Device Usage:</string>
+           </property>
+          </widget>
+         </item>
          <item row="0" column="1">
           <widget class="QProgressBar" name="progressBar">
            <property name="value">
@@ -405,13 +412,6 @@
            </property>
            <property name="wordWrap">
             <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0" rowspan="2" alignment="Qt::AlignVCenter">
-          <widget class="QLabel" name="deviceLabel">
-           <property name="text">
-            <string>Device Usage:</string>
            </property>
           </widget>
          </item>
@@ -445,11 +445,21 @@
           <property name="verticalSpacing">
            <number>6</number>
           </property>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Owner:</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="1">
            <widget class="QLineEdit" name="owner"/>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLineEdit" name="ownerGroup"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="label_9">
@@ -464,18 +474,8 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_8">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Owner:</string>
-            </property>
-           </widget>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="ownerGroup"/>
           </item>
          </layout>
         </widget>
@@ -736,6 +736,13 @@
                 </item>
                </layout>
               </item>
+              <item row="0" column="1" rowspan="3">
+               <widget class="Line" name="line">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+               </widget>
+              </item>
               <item row="0" column="2">
                <widget class="QCheckBox" name="checkBox_10">
                 <property name="text">
@@ -754,13 +761,6 @@
                <widget class="QCheckBox" name="checkBox_12">
                 <property name="text">
                  <string>SetGID</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1" rowspan="3">
-               <widget class="Line" name="line">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
                 </property>
                </widget>
               </item>

--- a/src/filedialog.ui
+++ b/src/filedialog.ui
@@ -69,16 +69,6 @@
      <item row="0" column="1">
       <widget class="QLineEdit" name="fileName"/>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="fileTypeLabel">
-       <property name="text">
-        <string>File type:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="fileTypeCombo"/>
-     </item>
      <item row="0" column="2" rowspan="2">
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="orientation">
@@ -88,6 +78,16 @@
         <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
        </property>
       </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="fileTypeLabel">
+       <property name="text">
+        <string>File type:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="fileTypeCombo"/>
      </item>
     </layout>
    </item>

--- a/src/filesearch.ui
+++ b/src/filesearch.ui
@@ -275,17 +275,10 @@
          <layout class="QFormLayout" name="formLayout">
           <item row="0" column="0">
            <layout class="QGridLayout" name="gridLayout_2">
-            <item row="1" column="0">
-             <widget class="QCheckBox" name="smallerThan">
+            <item row="0" column="0">
+             <widget class="QCheckBox" name="largerThan">
               <property name="text">
-               <string>Smaller than:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="2">
-             <widget class="QSpinBox" name="maxSize">
-              <property name="enabled">
-               <bool>false</bool>
+               <string>Larger than:</string>
               </property>
              </widget>
             </item>
@@ -293,13 +286,6 @@
              <widget class="QSpinBox" name="minSize">
               <property name="enabled">
                <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QCheckBox" name="largerThan">
-              <property name="text">
-               <string>Larger than:</string>
               </property>
              </widget>
             </item>
@@ -331,6 +317,20 @@
                 <string>GiB</string>
                </property>
               </item>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="smallerThan">
+              <property name="text">
+               <string>Smaller than:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QSpinBox" name="maxSize">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
              </widget>
             </item>
             <item row="1" column="3">
@@ -386,6 +386,16 @@
               </property>
              </widget>
             </item>
+            <item row="2" column="1">
+             <widget class="QDateEdit" name="maxTime">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="calendarPopup">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
             <item row="3" column="0">
              <widget class="QCheckBox" name="laterThan">
               <property name="text">
@@ -395,16 +405,6 @@
             </item>
             <item row="3" column="1">
              <widget class="QDateEdit" name="minTime">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="calendarPopup">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QDateEdit" name="maxTime">
               <property name="enabled">
                <bool>false</bool>
               </property>

--- a/src/mount-operation-password.ui
+++ b/src/mount-operation-password.ui
@@ -64,9 +64,6 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="username"/>
-     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="label">
        <property name="sizePolicy">
@@ -83,12 +80,21 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="QLineEdit" name="password">
-       <property name="echoMode">
-        <enum>QLineEdit::Password</enum>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="username"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="domainLabel">
+       <property name="text">
+        <string>&amp;Domain:</string>
+       </property>
+       <property name="buddy">
+        <cstring>domain</cstring>
        </property>
       </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="domain"/>
      </item>
      <item row="3" column="0">
       <widget class="QLabel" name="label_2">
@@ -106,18 +112,12 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="domainLabel">
-       <property name="text">
-        <string>&amp;Domain:</string>
-       </property>
-       <property name="buddy">
-        <cstring>domain</cstring>
+     <item row="3" column="1">
+      <widget class="QLineEdit" name="password">
+       <property name="echoMode">
+        <enum>QLineEdit::Password</enum>
        </property>
       </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLineEdit" name="domain"/>
      </item>
     </layout>
    </item>

--- a/src/rename-dialog.ui
+++ b/src/rename-dialog.ui
@@ -57,26 +57,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0" colspan="2">
-      <widget class="QLabel" name="srcLabel">
-       <property name="text">
-        <string>with the following file?</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLabel" name="srcInfo">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string notr="true">src file info</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="1">
       <widget class="QLabel" name="destInfo">
        <property name="sizePolicy">
@@ -90,6 +70,13 @@
        </property>
       </widget>
      </item>
+     <item row="1" column="0" colspan="2">
+      <widget class="QLabel" name="srcLabel">
+       <property name="text">
+        <string>with the following file?</string>
+       </property>
+      </widget>
+     </item>
      <item row="2" column="0">
       <widget class="QLabel" name="srcIcon">
        <property name="sizePolicy">
@@ -100,6 +87,19 @@
        </property>
        <property name="text">
         <string notr="true">src</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="srcInfo">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string notr="true">src file info</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Reordered XML .ui files to correct tab orders throughout libfm-qt.

There may be one or two .ui files that require <tabstops>, and/or changes to prevent StandardButtons causing incorrect ordering.

Affected files:
- app-chooser-dialog.ui
- edit-bookmarks.ui
- file-operation-dialog.ui
- file-props.ui
- filedialog.ui
- filesearch.ui
- mount-operation-password.ui
- rename-dialog.ui