### PR TITLE
Disallow input containing '/' in Fm::createFileOrFolder

### DIFF
--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -270,6 +270,7 @@ _retry:
         QDialogButtonBox *btns = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
         QObject::connect(btns, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
         QObject::connect(btns, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
+
         // layout
         QVBoxLayout *layout = new QVBoxLayout;
         layout->addWidget(label);
@@ -285,6 +286,10 @@ _retry:
         default:
             return;
         }
+    }
+
+    if(new_name.contains(QString::fromUtf8("/"))) {
+        goto _retry;
     }
 
     auto dest = parentDir.child(new_name.toLocal8Bit().data());


### PR DESCRIPTION
For the "Create New" menu, handling of entry containing '/' is inconsistent: relative paths work if the subdirectories exist; if the path doesn't exist then an error message is shown. Absolute paths do nothing, and lastly there is some funky behavior when the final character is '/'.

Renaming (`Fm::changeFileName`) also disallows '/': https://github.com/lxqt/libfm-qt/blob/eb1de483c106d6ba7786fe543969d487a5155f6f/src/utilities.cpp#L152

This change disallows entry containing '/' because the behavior is inconsistent, and it seems the dialogs weren't intended to be used with paths.
