### PR TITLE
Removed a redundant child-parent relation in pathbar

### DIFF
--- a/src/pathbar.cpp
+++ b/src/pathbar.cpp
@@ -73,7 +73,7 @@ PathBar::PathBar(QWidget* parent):
     topLayout->addWidget(scrollToEnd_);
 
     // container widget of the path buttons
-    buttonsWidget_ = new QWidget(this);
+    buttonsWidget_ = new QWidget;
     buttonsWidget_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
     buttonsLayout_ = new QHBoxLayout(buttonsWidget_);


### PR DESCRIPTION
In `PathBar`, `buttonsWidget_` becomes the child of `scrollArea_` when `QScrollArea::setWidget()` is called. So, there was no need to set `PathBar` as its parent.

NOTE: The reason I noticed this what that I encountered a crash in `QScrollArea::~QScrollArea()` with Qt 6.7, but only once. There have been other cases which show that something has changed about deleting objects in Qt 6.7 (see https://github.com/lxqt/lximage-qt/pull/666 and https://github.com/lxqt/lxqt-notificationd/pull/375). Regardless of whether it's about a new Qt bug or not, the patches are logical.