### PR TITLE
Select name without extension in overwrite prompts

### DIFF
--- a/src/renamedialog.cpp
+++ b/src/renamedialog.cpp
@@ -88,6 +88,13 @@ RenameDialog::RenameDialog(const FileInfo &src, const FileInfo &dest, QWidget* p
 
     auto basename = path.baseName();
     ui->fileName->setText(QString::fromUtf8(basename.get()));
+    int length = ui->fileName->text().lastIndexOf(QStringLiteral("."));
+    if(length > 0 && length < ui->fileName->text().size() - 1) {
+        ui->fileName->setSelection(0, length);
+    }
+    else {
+        ui->fileName->selectAll();
+    }
     oldName_ = QString::fromUtf8(basename.get());
     connect(ui->fileName, &QLineEdit::textChanged, this, &RenameDialog::onFileNameChanged);
     ui->fileName->setFocus(); // needed with Qt >= 6.6.1

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -260,7 +260,7 @@ _retry:
         // text entry
         QLineEdit *le = new QLineEdit(defaultNewName);
         int length = defaultNewName.lastIndexOf(QStringLiteral("."));
-        if(length > -1) {
+        if(length > 0 && length < defaultNewName.size() - 1) {
             le->setSelection(0, length);
         }
         else {


### PR DESCRIPTION
Qt6 automatically selects the whole name in overwrite prompts (while Qt5 selected nothing). This patch excludes the extension — if any — from the selection.