### PR TITLE
Add 6 menu icons

### DIFF
--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -115,7 +115,7 @@ FileMenu::FileMenu(Fm::FileInfoList files, std::shared_ptr<const Fm::FileInfo> i
         }
     }
     menu->addSeparator();
-    openWithAction_ = new QAction(tr("Other Applications"), this);
+    openWithAction_ = new QAction(QIcon::fromTheme(QStringLiteral("applications-other")), tr("Other Applications"), this);
     connect(openWithAction_, &QAction::triggered, this, &FileMenu::onOpenWithTriggered);
     menu->addAction(openWithAction_);
 
@@ -167,7 +167,7 @@ FileMenu::FileMenu(Fm::FileInfoList files, std::shared_ptr<const Fm::FileInfo> i
         connect(deleteAction_, &QAction::triggered, this, &FileMenu::onDeleteTriggered);
         addAction(deleteAction_);
 
-        renameAction_ = new QAction(tr("Rename"), this);
+        renameAction_ = new QAction(QIcon::fromTheme(QStringLiteral("edit-rename")), tr("Rename"), this);
         connect(renameAction_, &QAction::triggered, this, &FileMenu::onRenameTriggered);
         addAction(renameAction_);
 

--- a/src/pathbar.cpp
+++ b/src/pathbar.cpp
@@ -119,10 +119,10 @@ void PathBar::contextMenuEvent(QContextMenuEvent* event) {
     QMenu* menu = new QMenu(this);
     connect(menu, &QMenu::aboutToHide, menu, &QMenu::deleteLater);
 
-    QAction* action = menu->addAction(tr("&Edit Path"));
+    QAction* action = menu->addAction(QIcon::fromTheme(QStringLiteral("edit-rename")), tr("&Edit Path"));
     connect(action, &QAction::triggered, this, &PathBar::openEditor);
 
-    action = menu->addAction(tr("&Copy Path"));
+    action = menu->addAction(QIcon::fromTheme(QStringLiteral("edit-copy")), tr("&Copy Path"));
     connect(action, &QAction::triggered, this, &PathBar::copyPath);
 
     menu->popup(mapToGlobal(event->pos()));

--- a/src/placesview.cpp
+++ b/src/placesview.cpp
@@ -553,9 +553,11 @@ void PlacesView::contextMenuEvent(QContextMenuEvent* event) {
            && (item->type() != PlacesModelItem::Volume
                || static_cast<PlacesModelVolumeItem*>(item)->isMounted())) {
             action = new PlacesModel::ItemAction(item->index(), tr("Open in New Tab"), menu);
+            action->setIcon(QIcon::fromTheme(QStringLiteral("tab-new")));
             connect(action, &QAction::triggered, this, &PlacesView::onOpenNewTab);
             menu->addAction(action);
             action = new PlacesModel::ItemAction(item->index(), tr("Open in New Window"), menu);
+            action->setIcon(QIcon::fromTheme(QStringLiteral("window-new")));
             connect(action, &QAction::triggered, this, &PlacesView::onOpenNewWindow);
             menu->addAction(action);
         }


### PR DESCRIPTION
Add 6 context menu icons

File menu → Open With... → Other Applications: `categories/applications-other`
File menu → Rename: `actions/edit-rename`

Path bar (FM) → Copy Path: `actions/edit-copy`
Path bar (FM) → Edit Path: `actions/edit-rename`

Places View (FM) → Open in New Tab: `actions/tab-new`
Places View (FM) → Open in New Window: `actions/window-new`