### PR TITLE
Give parent to File Properties dialog from context menu

### DIFF
--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -427,7 +427,7 @@ void FileMenu::onTrustToggled(bool checked) {
 }
 
 void FileMenu::onFilePropertiesTriggered() {
-    FilePropsDialog::showForFiles(files_);
+    FilePropsDialog::showForFiles(files_, parentWidget() ? parentWidget()->window() : nullptr);
 }
 
 void FileMenu::onCopyTriggered() {

--- a/src/foldermenu.cpp
+++ b/src/foldermenu.cpp
@@ -355,7 +355,7 @@ void FolderMenu::onHiddenLastActionTriggered(bool checked) {
 void FolderMenu::onPropertiesActionTriggered() {
     auto folderInfo = view_->folderInfo();
     if(folderInfo) {
-        FilePropsDialog::showForFile(folderInfo);
+        FilePropsDialog::showForFile(folderInfo, view_->window());
     }
 }
 


### PR DESCRIPTION
Make it a child of the current window for it to be centered in front of the window.

The same behavior can be implemented for `Alt+Return/Enter` in pcmanfm-qt but, for now, let's have 2 ways of displaying it.

Closes https://github.com/lxqt/libfm-qt/issues/981