### PR TITLE
Add parent to Choose an Application dialog

### DIFF
--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -373,7 +373,7 @@ void FileMenu::onOpenTriggered() {
 }
 
 void FileMenu::onOpenWithTriggered() {
-    AppChooserDialog dlg(nullptr);
+    AppChooserDialog dlg(nullptr, parentWidget() ? parentWidget()->window() : nullptr);
     if(sameType_) {
         dlg.setMimeType(info_->mimeType());
     }


### PR DESCRIPTION
Same as #982 but for the Choose an Application dialog.

Fixes a bug in the Open File dialog where right-clicking a file → Open With → Other Applications, the dialog is inaccessible.

Note: There remains one `AppChooserDialog` ctor with a null parent: https://github.com/lxqt/libfm-qt/blob/ed5fd2f206b31c80b4c2d11e1fbc305bfc7b2144/src/filelauncher.cpp#L80 As I've never used launchers I was unsure what to do there.