### PR TITLE
Check real file name for filtering in file dialog

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -1420,7 +1420,7 @@ bool FileDialog::FileDialogFilter::filterAcceptsRow(const ProxyFolderModel* /*mo
     }
 
     bool nameMatched = false;
-    auto& name = info->displayName();
+    auto& name = (!info->name().empty() ? QString::fromStdString(info->name()) : info->displayName());
     for(const auto& pattern: patterns_) {
         if(name.indexOf(pattern) == 0) {
             nameMatched = true;


### PR DESCRIPTION
… and only if it's empty, check the display name. This fixes https://github.com/lxqt/libfm-qt/issues/193