### PR TITLE
Fixed side-pane text color with style change for Qt ≥ 6.7.2

### DIFF
--- a/src/sidepane.h
+++ b/src/sidepane.h
@@ -112,7 +112,7 @@ Q_SIGNALS:
     void hiddenPlaceSet(const QString& str, bool hide);
 
 protected:
-    bool event(QEvent* event) override;
+    bool eventFilter(QObject* watched, QEvent* event) override;
 
 protected Q_SLOTS:
     void onComboCurrentIndexChanged(int current);


### PR DESCRIPTION
This change has two advantages: it resets the text color when the change event happens to the view (and not when it happens to its parent); and it considers inactive colors too (although most styles ignore them).

Hopefully, Qt devs won't annoy us soon ;)