### PR TITLE
Improve side pane spacing

### DIFF
--- a/src/folderitemdelegate.h
+++ b/src/folderitemdelegate.h
@@ -66,6 +66,14 @@ public:
         iconInfoRole_ = role;
     }
 
+    int isHeaderRole() {
+        return isHeaderRole_;
+    }
+
+    void setIsHeaderRole(int role) {
+        isHeaderRole_ = role;
+    }
+
     // only support vertical layout (icon view mode: text below icon)
     void setShadowColor(const QColor& shadowColor) {
       shadowColor_ = shadowColor;
@@ -122,6 +130,9 @@ private:
     QSize itemSize_;
     int fileInfoRole_;
     int iconInfoRole_;
+    int isHeaderRole_;
+    int headerMarginTop_;
+    int headerMarginBottom_;
     QColor shadowColor_;
     QSize margins_;
     bool shadowHidden_;

--- a/src/placesmodel.cpp
+++ b/src/placesmodel.cpp
@@ -44,6 +44,7 @@ PlacesModel::PlacesModel(QObject* parent):
     setColumnCount(2);
 
     placesRoot = new QStandardItem(tr("Places"));
+    placesRoot->setData(true, PlacesModel::IsHeaderRole);
     placesRoot->setSelectable(false);
     placesRoot->setColumnCount(2);
     appendRow(placesRoot);
@@ -79,6 +80,7 @@ PlacesModel::PlacesModel(QObject* parent):
     }
 
     devicesRoot = new QStandardItem(tr("Devices"));
+    devicesRoot->setData(true, PlacesModel::IsHeaderRole);
     devicesRoot->setSelectable(false);
     devicesRoot->setColumnCount(2);
     appendRow(devicesRoot);
@@ -134,6 +136,7 @@ PlacesModel::PlacesModel(QObject* parent):
 
     // bookmarks
     bookmarksRoot = new QStandardItem(tr("Bookmarks"));
+    bookmarksRoot->setData(true, PlacesModel::IsHeaderRole);
     bookmarksRoot->setSelectable(false);
     bookmarksRoot->setColumnCount(2);
     appendRow(bookmarksRoot);

--- a/src/placesmodel.h
+++ b/src/placesmodel.h
@@ -46,7 +46,8 @@ public:
 
     enum {
         FileInfoRole = Qt::UserRole,
-        FmIconRole
+        FmIconRole,
+        IsHeaderRole
     };
 
     // QAction used for popup menus

--- a/src/placesview.cpp
+++ b/src/placesview.cpp
@@ -143,6 +143,7 @@ PlacesView::PlacesView(QWidget* parent):
     FolderItemDelegate* delegate = new FolderItemDelegate(this, this);
     delegate->setFileInfoRole(PlacesModel::FileInfoRole);
     delegate->setIconInfoRole(PlacesModel::FmIconRole);
+    delegate->setIsHeaderRole(PlacesModel::IsHeaderRole);
     setItemDelegateForColumn(0, delegate);
 
     model_ = PlacesModel::globalInstance();


### PR DESCRIPTION
Currently the spacing of items in the side pane list view is a bit off, there is less space between the headers and the items next to them than between the child items:
![screenshot-07a5d3cb](https://github.com/lxqt/libfm-qt/assets/125407598/b0c528d5-cbb8-4b13-ab28-356f217dc7e0)

That happens because the headers have no icons.
This changes that by making the headers taller.
Picture of before and after with the first header focused:
![focusbefore](https://github.com/lxqt/libfm-qt/assets/125407598/71919ddb-36c3-4498-abb8-2efd3ab5e5ae) ![focusafter](https://github.com/lxqt/libfm-qt/assets/125407598/a3aa5ecd-5e19-461b-bdea-e641b908450a)

Tested with different icon and font sizes and styles and scaling.