### PR TITLE
Fixed a vulnerability about trusted locations

### DIFF
--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -390,15 +390,14 @@ bool FileInfo::isExecutableType() const {
          they are native and have read permission */
         if(isNative() && (mode_ & (S_IRUSR|S_IRGRP|S_IROTH))) {
             if(isShortcut() && !target_.empty()) {
-                /* handle shortcuts from desktop to menu entries:
-                   first check for entries in /usr/share/applications and such
-                   which may be considered as a safe desktop entry path
-                   then check if that is a shortcut to a native file
-                   otherwise it is a link to a file under menu:// */
-                if (!g_str_has_prefix(target_.c_str(), "/usr/share/")) {
-                    auto target = FilePath::fromPathStr(target_.c_str());
-                    bool is_native = target.isNative();
-                    if (is_native) {
+                /* first check if this is a shortcut to a native file
+                   (otherwise it is a link to a file under menu://),
+                   then check for entries in /usr/share/applications and such
+                   which may be considered as a safe desktop entry path */
+                auto target = FilePath::fromPathStr(target_.c_str());
+                if(target.isNative()) {
+                    auto usrShare = FilePath::fromPathStr("/usr/share/");
+                    if(!usrShare.isPrefixOf(target)) {
                         return true;
                     }
                 }


### PR DESCRIPTION
With the master code, if you made a desktop entry like this (replace YOUR_USER_NAME with your user name):

```
[Desktop Entry]
Name=Test
Comment=
URL=/usr/share/../../home/YOUR_USER_NAME/Downloads/any.desktop
Type=Link
Icon=application-x-desktop
Terminal=false
```

then it would be considered "safe" and execute `/home/YOUR_USER_NAME/Downloads/any.desktop` without prompt. This patch fixes the issue by not relying on the relative paths.

This vulnerability was kindly reported by an attentive user via email. I wasn't sure if he wanted his name to be mentioned here.

NOTE: We can also trust `/usr/local/share/` or more paths, but IMHO there's no need to be too meticulous in this regard.