### PR TITLE
Prevent truncated labels in prompt for executing

### DIFF
--- a/src/exec-file.ui
+++ b/src/exec-file.ui
@@ -16,6 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
+     <property name="bottomMargin">
+      <number>10</number>
+     </property>
      <item>
       <widget class="QLabel" name="icon"/>
      </item>

--- a/src/execfiledialog.cpp
+++ b/src/execfiledialog.cpp
@@ -55,6 +55,7 @@ ExecFileDialog::ExecFileDialog(const FileInfo &fileInfo, QWidget* parent, Qt::Wi
     }
     ui->msg->setText(msg);
     ui->remBox->hide();
+    resize(sizeHint().expandedTo(QSize(400, 0))); // make sure that the label is shown completely (a Qt bug?)
 }
 
 ExecFileDialog::~ExecFileDialog() {
@@ -64,6 +65,7 @@ ExecFileDialog::~ExecFileDialog() {
 void ExecFileDialog::allowRemembering() {
     ui->remLayout->setContentsMargins(0, 10, 0, 0);
     ui->remBox->show();
+    resize(sizeHint().expandedTo(QSize(400, 0)));
 }
 
 bool ExecFileDialog::isRemembered() {


### PR DESCRIPTION
Due do a problem that I think is a Qt bug, the prompt label might not be shown completely, unless the dialog was resized.

Closes https://github.com/lxqt/libfm-qt/issues/993