### PR TITLE
Removed debug messages on launching

### DIFF
--- a/src/core/basicfilelauncher.cpp
+++ b/src/core/basicfilelauncher.cpp
@@ -330,7 +330,7 @@ FilePath BasicFileLauncher::handleShortcut(const FileInfoPtr& fileInfo, GAppLaun
     // if we know the target is a dir, we are not going to open it using other apps
     // for example: `network:///smb-root' is a shortcut targeting `smb:///' and it's also a dir
     if(fileInfo->isDir()) {
-        qDebug("shortcut is dir: %s", target.c_str());
+        //qDebug("shortcut is dir: %s", target.c_str());
         return FilePath::fromPathStr(target.c_str());
     }
 

--- a/src/core/legacy/fm-app-info.c
+++ b/src/core/legacy/fm-app-info.c
@@ -268,7 +268,7 @@ static gboolean do_launch(GAppInfo* appinfo, const char* full_desktop_path,
     GPid pid;
 
     cmd = expand_exec_macros(appinfo, full_desktop_path, kf, inp, &gfiles);
-    g_print("%s\n", cmd);
+    //g_print("%s\n", cmd);
     if (cmd == NULL || cmd[0] == '\0')
     {
         g_free(cmd);


### PR DESCRIPTION
Ordinary users don't need them, and coders know what to do. (Also see https://github.com/lxqt/libfm-qt/pull/998.)