### PR TITLE
Prevent truncated labels in file properties dialog

### DIFF
--- a/src/filepropsdialog.cpp
+++ b/src/filepropsdialog.cpp
@@ -73,6 +73,8 @@ FilePropsDialog::FilePropsDialog(Fm::FileInfoList files, QWidget* parent, Qt::Wi
         ui->contentsLabel->hide();
         ui->fileNumber->hide();
     }
+
+    resize(size().expandedTo(sizeHint())); // make sure that the labels are shown completely (a Qt bug?)
 }
 
 FilePropsDialog::~FilePropsDialog() {


### PR DESCRIPTION
Due do a Qt problem, long location labels might not be shown completely, unless the dialog was resized. (See https://github.com/lxqt/libfm-qt/pull/994 for a similar case.)