### PR TITLE
Fixed external thumbnails of relative symlinks

### DIFF
--- a/src/core/thumbnailjob.cpp
+++ b/src/core/thumbnailjob.cpp
@@ -88,7 +88,14 @@ QImage ThumbnailJob::loadForFile(const std::shared_ptr<const FileInfo> &file) {
         // if the file is changed to a symlink with the same time stamp
         auto target = file->target();
         if(!target.empty()) {
-            uri = FilePath::fromLocalPath(target.c_str()).uri();
+            if(auto dirPath = file->dirPath()) {
+                // "FilePath relativePath()" also covers absolute path names
+                // because "g_file_resolve_relative_path()" does
+                uri = dirPath.relativePath(target.c_str()).uri();
+            }
+            else {
+                uri = FilePath::fromLocalPath(target.c_str()).uri();
+            }
         }
     }
     if(!uri) {


### PR DESCRIPTION
Previously, external thumbnailers didn't work with relative symlinks. Fixes https://github.com/lxqt/pcmanfm-qt/issues/1934