### PR TITLE
Enabled the setting about local-only thumbnails

### DIFF
--- a/src/core/filesysteminfojob.cpp
+++ b/src/core/filesysteminfojob.cpp
@@ -8,7 +8,8 @@ void FileSystemInfoJob::exec() {
             g_file_query_filesystem_info(
                 path_.gfile().get(),
                 G_FILE_ATTRIBUTE_FILESYSTEM_SIZE","
-                G_FILE_ATTRIBUTE_FILESYSTEM_FREE,
+                G_FILE_ATTRIBUTE_FILESYSTEM_FREE","
+                G_FILE_ATTRIBUTE_FILESYSTEM_REMOTE,
                 cancellable().get(), nullptr),
             false
     };
@@ -18,6 +19,9 @@ void FileSystemInfoJob::exec() {
         size_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_FILESYSTEM_SIZE);
         freeSize_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_FILESYSTEM_FREE);
         isAvailable_ = true;
+    }
+    if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_FILESYSTEM_REMOTE)) {
+        isRemote_ = g_file_info_get_attribute_boolean(inf.get(), G_FILE_ATTRIBUTE_FILESYSTEM_REMOTE);
     }
 }
 

--- a/src/core/filesysteminfojob.h
+++ b/src/core/filesysteminfojob.h
@@ -13,12 +13,17 @@ public:
     explicit FileSystemInfoJob(const FilePath& path):
         path_{path},
         isAvailable_{false},
+        isRemote_{false},
         size_{0},
         freeSize_{0} {
     }
 
     bool isAvailable() const {
         return isAvailable_;
+    }
+
+    bool isRemote() const {
+        return isRemote_;
     }
 
     uint64_t size() const {
@@ -36,6 +41,7 @@ protected:
 private:
     FilePath path_;
     bool isAvailable_;
+    bool isRemote_;
     uint64_t size_;
     uint64_t freeSize_;
 };

--- a/src/core/folder.cpp
+++ b/src/core/folder.cpp
@@ -51,6 +51,7 @@ Folder::Folder():
     fs_total_size{0},
     fs_free_size{0},
     has_fs_info{false},
+    fs_remote{false},
     defer_content_test{false} {
 
     connect(volumeManager_.get(), &VolumeManager::mountAdded, this, &Folder::onMountAdded);
@@ -812,14 +813,21 @@ bool Folder::getFilesystemInfo(uint64_t* total_size, uint64_t* free_size) const 
 }
 
 
+bool Folder::getFilesystemRemote() const {
+    return fs_remote;
+}
+
+
 void Folder::onFileSystemInfoFinished() {
     FileSystemInfoJob* job = static_cast<FileSystemInfoJob*>(sender());
     if(job->isCancelled() || job != fsInfoJob_) { // this is a cancelled job, ignore!
         fsInfoJob_ = nullptr;
         has_fs_info = false;
+        fs_remote = false;
         return;
     }
     has_fs_info = job->isAvailable();
+    fs_remote = job->isRemote();
     fs_total_size = job->size();
     fs_free_size = job->freeSize();
     filesystem_info_pending = true;

--- a/src/core/folder.h
+++ b/src/core/folder.h
@@ -64,6 +64,8 @@ public:
 
     bool getFilesystemInfo(uint64_t* total_size, uint64_t* free_size) const;
 
+    bool getFilesystemRemote() const;
+
     void reload();
 
     bool isIncremental() const;
@@ -184,6 +186,7 @@ private:
     GCancellablePtr fs_size_cancellable;
 
     bool has_fs_info : 1;
+    bool fs_remote : 1;
     bool defer_content_test : 1;
 
     static std::unordered_map<FilePath, std::weak_ptr<Folder>, FilePathHash> cache_;

--- a/src/core/thumbnailjob.cpp
+++ b/src/core/thumbnailjob.cpp
@@ -17,9 +17,10 @@ bool ThumbnailJob::localFilesOnly_ = true;
 int ThumbnailJob::maxThumbnailFileSize_ = 4096; // in KiB
 int ThumbnailJob::maxExternalThumbnailFileSize_ = -1;
 
-ThumbnailJob::ThumbnailJob(FileInfoList files, int size):
+ThumbnailJob::ThumbnailJob(FileInfoList files, int size, bool isRemote):
     files_{std::move(files)},
     size_{size},
+    isRemote_{isRemote},
     md5Calc_{g_checksum_new(G_CHECKSUM_MD5)} {
 }
 
@@ -63,6 +64,10 @@ QImage ThumbnailJob::readImageFromStream(GInputStream* stream, size_t len) {
 
 QImage ThumbnailJob::loadForFile(const std::shared_ptr<const FileInfo> &file) {
     if(!file->canThumbnail()) {
+        return QImage();
+    }
+
+    if(localFilesOnly_ && isRemote_) {
         return QImage();
     }
 

--- a/src/core/thumbnailjob.h
+++ b/src/core/thumbnailjob.h
@@ -13,7 +13,7 @@ class LIBFM_QT_API ThumbnailJob: public Job {
     Q_OBJECT
 public:
 
-    explicit ThumbnailJob(FileInfoList files, int size);
+    explicit ThumbnailJob(FileInfoList files, int size, bool isRemote = false);
 
     ~ThumbnailJob() override;
 
@@ -69,6 +69,7 @@ private:
 private:
     FileInfoList files_;
     int size_;
+    bool isRemote_;
     std::vector<QImage> results_;
     GCancellablePtr cancellable_;
     GChecksum* md5Calc_;

--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -142,7 +142,7 @@ void FolderModel::loadPendingThumbnails() {
     hasPendingThumbnailHandler_ = false;
     for(auto& item: thumbnailData_) {
         if(!item.pendingThumbnails_.empty()) {
-            auto job = new Fm::ThumbnailJob(std::move(item.pendingThumbnails_), item.size_);
+            auto job = new Fm::ThumbnailJob(std::move(item.pendingThumbnails_), item.size_, folder_ != nullptr && folder_->getFilesystemRemote());
             pendingThumbnailJobs_.push_back(job);
             job->setAutoDelete(true);
             connect(job, &Fm::ThumbnailJob::thumbnailLoaded, this, &FolderModel::onThumbnailLoaded, Qt::BlockingQueuedConnection);


### PR DESCRIPTION
The code relies on the attribute `G_FILE_ATTRIBUTE_FILESYSTEM_REMOTE`; whether it's set correctly or not is the responsibility of GLib/GVFS.

Closes https://github.com/lxqt/libfm-qt/issues/643

NOTE1: To be on the safe side, recompile all apps that are based on libfm-qt — but I didn't :P

NOTE2: I haven't seen an external thumbnailer that works with remote files. So, this is mostly about libfm-qt's internal thumbnailer.