### PR TITLE
Detect remote and read-only file systems

### DIFF
--- a/src/core/dirlistjob.cpp
+++ b/src/core/dirlistjob.cpp
@@ -51,6 +51,29 @@ _retry:
         return;
     }
     else {
+        // First set the attributes "filesystem::readonly" and "filesystem::remote",
+        // which will be queried by FileInfo and are useful only for the parent dir.
+        if(GFileInfoPtr fs_info{
+            g_file_query_filesystem_info(dir_gfile.get(),
+                                         G_FILE_ATTRIBUTE_FILESYSTEM_READONLY","
+                                         G_FILE_ATTRIBUTE_FILESYSTEM_REMOTE,
+                                         cancellable().get(), nullptr),
+            false
+        }) {
+            if(g_file_info_has_attribute(fs_info.get(), G_FILE_ATTRIBUTE_FILESYSTEM_READONLY)) {
+                g_file_info_set_attribute_boolean(dir_inf.get(),
+                                                  G_FILE_ATTRIBUTE_FILESYSTEM_READONLY,
+                                                  g_file_info_get_attribute_boolean(fs_info.get(),
+                                                                                    G_FILE_ATTRIBUTE_FILESYSTEM_READONLY));
+            }
+            if(g_file_info_has_attribute(fs_info.get(), G_FILE_ATTRIBUTE_FILESYSTEM_REMOTE)) {
+                g_file_info_set_attribute_boolean(dir_inf.get(),
+                                                  G_FILE_ATTRIBUTE_FILESYSTEM_REMOTE,
+                                                  g_file_info_get_attribute_boolean(fs_info.get(),
+                                                                                    G_FILE_ATTRIBUTE_FILESYSTEM_REMOTE));
+            }
+        }
+
         std::lock_guard<std::mutex> lock{mutex_};
         dir_fi = std::make_shared<FileInfo>(dir_inf, dir_path);
     }

--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -164,6 +164,9 @@ void FileInfo::setFromGFileInfo(const GObjectPtr<GFileInfo>& inf, const FilePath
         }
     }
 
+    isReadOnly_ = false; /* default is R/W */
+    isRemote_ = false; /* default is local */
+
     /* special handling for symlinks */
     if(g_file_info_get_attribute_boolean(inf.get(), G_FILE_ATTRIBUTE_STANDARD_IS_SYMLINK)) {
         mode_ &= ~S_IFMT; /* reset type */
@@ -204,13 +207,15 @@ void FileInfo::setFromGFileInfo(const GObjectPtr<GFileInfo>& inf, const FilePath
         if(!mimeType_) {
             mimeType_ = MimeType::inodeDirectory();
         }
-        isReadOnly_ = false; /* default is R/W */
         if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_FILESYSTEM_READONLY)) {
             isReadOnly_ = g_file_info_get_attribute_boolean(inf.get(), G_FILE_ATTRIBUTE_FILESYSTEM_READONLY);
         }
-        /* directories should be writable to be deleted by user */
         if(isReadOnly_ || !isWritable_) {
+            /* directories should be writable to be deleted by user */
             isDeletable_ = false;
+        }
+        if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_FILESYSTEM_REMOTE)) {
+            isRemote_ = g_file_info_get_attribute_boolean(inf.get(), G_FILE_ATTRIBUTE_FILESYSTEM_REMOTE);
         }
         break;
     case G_FILE_TYPE_SYMBOLIC_LINK:

--- a/src/core/fileinfo.h
+++ b/src/core/fileinfo.h
@@ -120,6 +120,10 @@ public:
         return (!isReadOnly_ && isDir());
     }
 
+    bool isRemoteDirectory() const {
+        return (isRemote_ && isDir());
+    }
+
     bool isAccessible() const {
         return isAccessible_;
     }
@@ -280,6 +284,7 @@ private:
     bool isIconChangeable_ : 1; /* TRUE if icon can be changed */
     bool isHiddenChangeable_ : 1; /* TRUE if hidden can be changed */
     bool isReadOnly_ : 1; /* TRUE if host FS is R/O */
+    bool isRemote_ : 1; /* TRUE if host FS is remote */
     bool canMount_ : 1;  /* TRUE if can be mounted */
     bool canUnmount_ : 1; /* TRUE if can be unmounted */
     bool canEject_ : 1; /* TRUE if can be ejected */

--- a/src/core/thumbnailjob.cpp
+++ b/src/core/thumbnailjob.cpp
@@ -17,9 +17,10 @@ bool ThumbnailJob::localFilesOnly_ = true;
 int ThumbnailJob::maxThumbnailFileSize_ = 4096; // in KiB
 int ThumbnailJob::maxExternalThumbnailFileSize_ = -1;
 
-ThumbnailJob::ThumbnailJob(FileInfoList files, int size):
+ThumbnailJob::ThumbnailJob(FileInfoList files, int size, bool isRemote):
     files_{std::move(files)},
     size_{size},
+    isRemote_{isRemote},
     md5Calc_{g_checksum_new(G_CHECKSUM_MD5)} {
 }
 
@@ -63,6 +64,10 @@ QImage ThumbnailJob::readImageFromStream(GInputStream* stream, size_t len) {
 
 QImage ThumbnailJob::loadForFile(const std::shared_ptr<const FileInfo> &file) {
     if(!file->canThumbnail()) {
+        return QImage();
+    }
+
+    if(localFilesOnly_ && isRemote_) {
         return QImage();
     }
 

--- a/src/core/thumbnailjob.h
+++ b/src/core/thumbnailjob.h
@@ -13,7 +13,7 @@ class LIBFM_QT_API ThumbnailJob: public Job {
     Q_OBJECT
 public:
 
-    explicit ThumbnailJob(FileInfoList files, int size);
+    explicit ThumbnailJob(FileInfoList files, int size, bool isRemote = false);
 
     ~ThumbnailJob() override;
 
@@ -69,6 +69,7 @@ private:
 private:
     FileInfoList files_;
     int size_;
+    bool isRemote_;
     std::vector<QImage> results_;
     GCancellablePtr cancellable_;
     GChecksum* md5Calc_;

--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -142,7 +142,7 @@ void FolderModel::loadPendingThumbnails() {
     hasPendingThumbnailHandler_ = false;
     for(auto& item: thumbnailData_) {
         if(!item.pendingThumbnails_.empty()) {
-            auto job = new Fm::ThumbnailJob(std::move(item.pendingThumbnails_), item.size_);
+            auto job = new Fm::ThumbnailJob(std::move(item.pendingThumbnails_), item.size_, folder_ != nullptr && folder_->isValid() && folder_->info()->isRemoteDirectory());
             pendingThumbnailJobs_.push_back(job);
             job->setAutoDelete(true);
             connect(job, &Fm::ThumbnailJob::thumbnailLoaded, this, &FolderModel::onThumbnailLoaded, Qt::BlockingQueuedConnection);


### PR DESCRIPTION
The patch does it only by a single info query for the parent directory. So, it shouldn't affect the speed.

Also, the setting about local-only thumbnails is enabled in this way.

Closes https://github.com/lxqt/libfm-qt/issues/643 and fixes https://github.com/lxqt/libfm-qt/issues/1006

NOTE: To be on the safe side, recompile libfm-qt based apps — although the LXQt apps don't seem to need that.

REMINDER: Add an option to lximage-qt for local-only thumbnails if this PR is merged.