### PR TITLE
Modernized string literals

### DIFF
--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -313,8 +313,8 @@ _file_is_symlink:
     // g_file_info_get_is_backup() does not cover ".bak" and ".old".
     // NOTE: Here, dispName_ is not modified for desktop entries yet.
     isBackup_ = g_file_info_get_attribute_boolean (inf.get(), G_FILE_ATTRIBUTE_STANDARD_IS_BACKUP)
-                || dispName_.endsWith(QLatin1String(".bak"))
-                || dispName_.endsWith(QLatin1String(".old"));
+                || dispName_.endsWith(QLatin1StringView(".bak"))
+                || dispName_.endsWith(QLatin1StringView(".old"));
     isNameChangeable_ = true; /* GVFS tends to ignore this attribute */
     isIconChangeable_ = isHiddenChangeable_ = false;
     if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_ACCESS_CAN_RENAME)) {

--- a/src/core/thumbnailjob.cpp
+++ b/src/core/thumbnailjob.cpp
@@ -73,16 +73,16 @@ QImage ThumbnailJob::loadForFile(const std::shared_ptr<const FileInfo> &file) {
 
     // thumbnails are stored in $XDG_CACHE_HOME/thumbnails/large|normal|failed
     QString thumbnailDir{QString::fromUtf8(g_get_user_cache_dir())};
-    thumbnailDir += QLatin1String("/thumbnails/");
+    thumbnailDir += QLatin1StringView("/thumbnails/");
 
     // don't make thumbnails for files inside the thumbnail directory
     if(file->dirPath() && FilePath::fromLocalPath(thumbnailDir.toLocal8Bit().constData()).isParentOf(file->dirPath())) {
         return QImage();
     }
 
-    QLatin1String subdir = size_ > 256 ? QLatin1String("x-large")
-                                       : size_ > 128 ? QLatin1String("large")
-                                                     : QLatin1String("normal");
+    QLatin1StringView subdir = size_ > 256 ? QLatin1StringView("x-large")
+                                           : size_ > 128 ? QLatin1StringView("large")
+                                                         : QLatin1StringView("normal");
     thumbnailDir += subdir;
 
     // generate base name of the thumbnail  => {md5 of uri}.png

--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -20,6 +20,8 @@
 #include <QTimer>
 #include <QDebug>
 
+using namespace Qt::Literals::StringLiterals;
+
 namespace Fm {
 
 
@@ -108,14 +110,14 @@ FileDialog::FileDialog(QWidget* parent, FilePath path) :
     // setup toolbar buttons
     auto toolbar = new QToolBar(this);
     // back button
-    backAction_ = toolbar->addAction(QIcon::fromTheme(QStringLiteral("go-previous")), tr("Go Back"));
+    backAction_ = toolbar->addAction(QIcon::fromTheme(u"go-previous"_s), tr("Go Back"));
     backAction_->setShortcut(QKeySequence(tr("Alt+Left", "Go Back")));
     connect(backAction_, &QAction::triggered, [this]() {
         history_.backward();
         setDirectoryPath(history_.currentPath(), FilePath(), false);
     });
     // forward button
-    forwardAction_ = toolbar->addAction(QIcon::fromTheme(QStringLiteral("go-next")), tr("Go Forward"));
+    forwardAction_ = toolbar->addAction(QIcon::fromTheme(u"go-next"_s), tr("Go Forward"));
     forwardAction_->setShortcut(QKeySequence(tr("Alt+Right", "Go Forward")));
     connect(forwardAction_, &QAction::triggered, [this]() {
         history_.forward();
@@ -123,7 +125,7 @@ FileDialog::FileDialog(QWidget* parent, FilePath path) :
     });
     toolbar->addSeparator();
     // reload button
-    auto reloadAction = toolbar->addAction(QIcon::fromTheme(QStringLiteral("view-refresh")), tr("Reload"));
+    auto reloadAction = toolbar->addAction(QIcon::fromTheme(u"view-refresh"_s), tr("Reload"));
     reloadAction->setShortcut(QKeySequence(tr("F5", "Reload")));
     connect(reloadAction, &QAction::triggered, [this]() {
         if(folder_ && folder_->isLoaded()) {
@@ -141,7 +143,7 @@ FileDialog::FileDialog(QWidget* parent, FilePath path) :
         }
     });
     // new folder button
-    auto newFolderAction = toolbar->addAction(QIcon::fromTheme(QStringLiteral("folder-new")), tr("Create Folder"));
+    auto newFolderAction = toolbar->addAction(QIcon::fromTheme(u"folder-new"_s), tr("Create Folder"));
     connect(newFolderAction, &QAction::triggered, this, &FileDialog::onNewFolder);
     toolbar->addSeparator();
 
@@ -157,19 +159,19 @@ FileDialog::FileDialog(QWidget* parent, FilePath path) :
     // view actions
     auto viewModeGroup = new QActionGroup(this);
     // use generic icons for view actions only if theme icons don't exist
-    iconViewAction_ = menu->addAction(QIcon::fromTheme(QLatin1String("view-list-icons"), style()->standardIcon(QStyle::SP_FileDialogContentsView)), tr("Icon View"));
+    iconViewAction_ = menu->addAction(QIcon::fromTheme(u"view-list-icons"_s, style()->standardIcon(QStyle::SP_FileDialogContentsView)), tr("Icon View"));
     iconViewAction_->setCheckable(true);
     connect(iconViewAction_, &QAction::toggled, this, &FileDialog::onViewModeToggled);
     viewModeGroup->addAction(iconViewAction_);
-    thumbnailViewAction_ = menu->addAction(QIcon::fromTheme(QLatin1String("view-preview"), style()->standardIcon(QStyle::SP_FileDialogInfoView)), tr("Thumbnail View"));
+    thumbnailViewAction_ = menu->addAction(QIcon::fromTheme(u"view-preview"_s, style()->standardIcon(QStyle::SP_FileDialogInfoView)), tr("Thumbnail View"));
     thumbnailViewAction_->setCheckable(true);
     connect(thumbnailViewAction_, &QAction::toggled, this, &FileDialog::onViewModeToggled);
     viewModeGroup->addAction(thumbnailViewAction_);
-    compactViewAction_ = menu->addAction(QIcon::fromTheme(QLatin1String("view-list-text"), style()->standardIcon(QStyle::SP_FileDialogListView)), tr("Compact View"));
+    compactViewAction_ = menu->addAction(QIcon::fromTheme(u"view-list-text"_s, style()->standardIcon(QStyle::SP_FileDialogListView)), tr("Compact View"));
     compactViewAction_->setCheckable(true);
     connect(compactViewAction_, &QAction::toggled, this, &FileDialog::onViewModeToggled);
     viewModeGroup->addAction(compactViewAction_);
-    detailedViewAction_ = menu->addAction(QIcon::fromTheme(QLatin1String("view-list-details"), style()->standardIcon(QStyle::SP_FileDialogDetailedView)), tr("Detailed List View"));
+    detailedViewAction_ = menu->addAction(QIcon::fromTheme(u"view-list-details"_s, style()->standardIcon(QStyle::SP_FileDialogDetailedView)), tr("Detailed List View"));
     detailedViewAction_->setCheckable(true);
     connect(detailedViewAction_, &QAction::toggled, this, &FileDialog::onViewModeToggled);
     viewModeGroup->addAction(detailedViewAction_);
@@ -248,7 +250,7 @@ FileDialog::FileDialog(QWidget* parent, FilePath path) :
     });
 
     // Options menu button
-    auto optionsAction = toolbar->addAction(QIcon::fromTheme(QStringLiteral("preferences-system"), QIcon::fromTheme(QStringLiteral("document-properties"))), tr("Options"));
+    auto optionsAction = toolbar->addAction(QIcon::fromTheme(u"preferences-system"_s, QIcon::fromTheme(u"document-properties"_s)), tr("Options"));
     optionsAction->setMenu(menu);
     // change the popup mode to instant (Qt sets it to MenuButtonPopup)
     if(QToolButton* optionsBtn = static_cast<QToolButton*>(toolbar->widgetForAction(optionsAction))) {
@@ -508,12 +510,12 @@ QStringList FileDialog::parseNames() const {
            && (firstQuote == 0 || fileNames.at(firstQuote - 1) != QLatin1Char('\\'))
            && fileNames.at(lastQuote - 1) != QLatin1Char('\\')) {
            // split the names
-            QRegularExpression sep{QStringLiteral("\"\\s+\"")};  // separated with " "
+            QRegularExpression sep{u"\"\\s+\""_s};  // separated with " "
             parsedNames = fileNames.mid(firstQuote + 1, lastQuote - firstQuote - 1).split(sep);
-            parsedNames.replaceInStrings(QLatin1String("\\\""), QLatin1String("\""));
+            parsedNames.replaceInStrings(u"\\\""_s, u"\""_s);
         }
         else {
-            parsedNames << fileNames.replace(QLatin1String("\\\""), QLatin1String("\""));
+            parsedNames << fileNames.replace("\\\""_L1, "\""_L1);
         }
     }
     return parsedNames;
@@ -548,7 +550,7 @@ QString FileDialog::suffix(bool checkDefaultSuffix) const {
                 left = suffix.indexOf(QLatin1Char('.')); // it can be like ".tar.xz"
                 if(left != -1 && suffix.size() - left > 1) {
                     suffix = suffix.right(suffix.size() - left - 1);
-                    if(suffix.indexOf(QRegularExpression(QStringLiteral("[^\\w\\.]"))) == -1) {
+                    if(suffix.indexOf(QRegularExpression(u"[^\\w\\.]"_s)) == -1) {
                         return suffix;
                     }
                 }
@@ -907,13 +909,13 @@ void FileDialog::onSelectionChanged(const QItemSelection& /*selected*/, const QI
             // escape inside quotes with \ to distinguish between them
             // and the quotes used for separating file names from each other
             QString name(QString::fromUtf8(baseName.get()));
-            fileNames += name.replace(QLatin1String("\""), QLatin1String("\\\""));
+            fileNames += name.replace("\""_L1, "\\\""_L1);
             fileNames += QLatin1Char('\"');
         }
         else {
             // support single selection only
             QString name(QString::fromUtf8(baseName.get()));
-            fileNames = name.replace(QLatin1String("\""), QLatin1String("\\\""));
+            fileNames = name.replace("\""_L1, "\\\""_L1);
             break;
         }
     }
@@ -1225,10 +1227,10 @@ void FileDialog::setMimeTypeFilters(const QStringList& filters) {
         auto mimeType = db.mimeTypeForName(filter);
         auto nameFilter = mimeType.comment();
         if(!mimeType.suffixes().empty()) {
-            nameFilter += QLatin1String(" (");
+            nameFilter += " ("_L1;
             const auto suffixes = mimeType.suffixes();
             for(const auto& suffix: suffixes) {
-                nameFilter += QLatin1String("*.");
+                nameFilter += "*."_L1;
                 nameFilter += suffix;
                 nameFilter += QLatin1Char(' ');
             }

--- a/src/filedialoghelper.cpp
+++ b/src/filedialoghelper.cpp
@@ -12,6 +12,8 @@
 
 #include <memory>
 
+using namespace Qt::Literals::StringLiterals;
+
 namespace Fm {
 
 inline static const QString viewModeToString(Fm::FolderView::ViewMode value);
@@ -191,16 +193,16 @@ static const QString viewModeToString(Fm::FolderView::ViewMode value) {
     switch(value) {
     case Fm::FolderView::DetailedListMode:
     default:
-        ret = QLatin1String("Detailed");
+        ret = "Detailed"_L1;
         break;
     case Fm::FolderView::CompactMode:
-        ret = QLatin1String("Compact");
+        ret = "Compact"_L1;
         break;
     case Fm::FolderView::IconMode:
-        ret = QLatin1String("Icon");
+        ret = "Icon"_L1;
         break;
     case Fm::FolderView::ThumbnailMode:
-        ret = QLatin1String("Thumbnail");
+        ret = "Thumbnail"_L1;
         break;
     }
     return ret;
@@ -208,16 +210,16 @@ static const QString viewModeToString(Fm::FolderView::ViewMode value) {
 
 Fm::FolderView::ViewMode viewModeFromString(const QString& str) {
     Fm::FolderView::ViewMode ret;
-    if(str == QLatin1String("Detailed")) {
+    if(str == "Detailed"_L1) {
         ret = Fm::FolderView::DetailedListMode;
     }
-    else if(str == QLatin1String("Compact")) {
+    else if(str == "Compact"_L1) {
         ret = Fm::FolderView::CompactMode;
     }
-    else if(str == QLatin1String("Icon")) {
+    else if(str == "Icon"_L1) {
         ret = Fm::FolderView::IconMode;
     }
-    else if(str == QLatin1String("Thumbnail")) {
+    else if(str == "Thumbnail"_L1) {
         ret = Fm::FolderView::ThumbnailMode;
     }
     else {
@@ -228,28 +230,28 @@ Fm::FolderView::ViewMode viewModeFromString(const QString& str) {
 
 static Fm::FolderModel::ColumnId sortColumnFromString(const QString str) {
     Fm::FolderModel::ColumnId ret;
-    if(str == QLatin1String("name")) {
+    if(str == "name"_L1) {
         ret = Fm::FolderModel::ColumnFileName;
     }
-    else if(str == QLatin1String("type")) {
+    else if(str == "type"_L1) {
         ret = Fm::FolderModel::ColumnFileType;
     }
-    else if(str == QLatin1String("size")) {
+    else if(str == "size"_L1) {
         ret = Fm::FolderModel::ColumnFileSize;
     }
-    else if(str == QLatin1String("mtime")) {
+    else if(str == "mtime"_L1) {
         ret = Fm::FolderModel::ColumnFileMTime;
     }
-    else if(str == QLatin1String("crtime")) {
+    else if(str == "crtime"_L1) {
         ret = Fm::FolderModel::ColumnFileCrTime;
     }
-    else if(str == QLatin1String("dtime")) {
+    else if(str == "dtime"_L1) {
         ret = Fm::FolderModel::ColumnFileDTime;
     }
-    else if(str == QLatin1String("owner")) {
+    else if(str == "owner"_L1) {
         ret = Fm::FolderModel::ColumnFileOwner;
     }
-    else if(str == QLatin1String("group")) {
+    else if(str == "group"_L1) {
         ret = Fm::FolderModel::ColumnFileGroup;
     }
     else {
@@ -263,65 +265,65 @@ static const QString sortColumnToString(Fm::FolderModel::ColumnId value) {
     switch(value) {
     case Fm::FolderModel::ColumnFileName:
     default:
-        ret = QLatin1String("name");
+        ret = "name"_L1;
         break;
     case Fm::FolderModel::ColumnFileType:
-        ret = QLatin1String("type");
+        ret = "type"_L1;
         break;
     case Fm::FolderModel::ColumnFileSize:
-        ret = QLatin1String("size");
+        ret = "size"_L1;
         break;
     case Fm::FolderModel::ColumnFileMTime:
-        ret = QLatin1String("mtime");
+        ret = "mtime"_L1;
         break;
     case Fm::FolderModel::ColumnFileCrTime:
-        ret = QLatin1String("crtime");
+        ret = "crtime"_L1;
         break;
     case Fm::FolderModel::ColumnFileDTime:
-        ret = QLatin1String("dtime");
+        ret = "dtime"_L1;
         break;
     case Fm::FolderModel::ColumnFileOwner:
-        ret = QLatin1String("owner");
+        ret = "owner"_L1;
         break;
     case Fm::FolderModel::ColumnFileGroup:
-        ret = QLatin1String("group");
+        ret = "group"_L1;
         break;
     }
     return ret;
 }
 
 static const QString sortOrderToString(Qt::SortOrder order) {
-    return (order == Qt::DescendingOrder ? QLatin1String("descending") : QLatin1String("ascending"));
+    return (order == Qt::DescendingOrder ? "descending"_L1 : "ascending"_L1);
 }
 
 static Qt::SortOrder sortOrderFromString(const QString str) {
-    return (str == QLatin1String("descending") ? Qt::DescendingOrder : Qt::AscendingOrder);
+    return (str == "descending"_L1 ? Qt::DescendingOrder : Qt::AscendingOrder);
 }
 
 void FileDialogHelper::loadSettings() {
-    QSettings settings(QSettings::UserScope, QStringLiteral("lxqt"), QStringLiteral("filedialog"));
-    settings.beginGroup (QStringLiteral("Sizes"));
-    dlg_->resize(settings.value(QStringLiteral("WindowSize"), QSize(700, 500)).toSize());
-    dlg_->setSplitterPos(settings.value(QStringLiteral("SplitterPos"), 200).toInt());
+    QSettings settings(QSettings::UserScope, "lxqt"_L1, "filedialog"_L1);
+    settings.beginGroup ("Sizes"_L1);
+    dlg_->resize(settings.value("WindowSize"_L1, QSize(700, 500)).toSize());
+    dlg_->setSplitterPos(settings.value("SplitterPos"_L1, 200).toInt());
     settings.endGroup();
 
-    settings.beginGroup (QStringLiteral("View"));
-    dlg_->setViewMode(viewModeFromString(settings.value(QStringLiteral("Mode"), QStringLiteral("Detailed")).toString()));
-    dlg_->sort(sortColumnFromString(settings.value(QStringLiteral("SortColumn")).toString()), sortOrderFromString(settings.value(QStringLiteral("SortOrder")).toString()));
-    dlg_->setSortFolderFirst(settings.value(QStringLiteral("SortFolderFirst"), true).toBool());
-    dlg_->setSortHiddenLast(settings.value(QStringLiteral("SortHiddenLast"), false).toBool());
-    dlg_->setSortCaseSensitive(settings.value(QStringLiteral("SortCaseSensitive"), false).toBool());
-    dlg_->setShowHidden(settings.value(QStringLiteral("ShowHidden"), false).toBool());
+    settings.beginGroup ("View"_L1);
+    dlg_->setViewMode(viewModeFromString(settings.value("Mode"_L1, "Detailed"_L1).toString()));
+    dlg_->sort(sortColumnFromString(settings.value("SortColumn"_L1).toString()), sortOrderFromString(settings.value("SortOrder"_L1).toString()));
+    dlg_->setSortFolderFirst(settings.value("SortFolderFirst"_L1, true).toBool());
+    dlg_->setSortHiddenLast(settings.value("SortHiddenLast"_L1, false).toBool());
+    dlg_->setSortCaseSensitive(settings.value("SortCaseSensitive"_L1, false).toBool());
+    dlg_->setShowHidden(settings.value("ShowHidden"_L1, false).toBool());
 
-    dlg_->setShowThumbnails(settings.value(QStringLiteral("ShowThumbnails"), true).toBool());
-    dlg_->setNoItemTooltip(settings.value(QStringLiteral("NoItemTooltip"), false).toBool());
-    dlg_->setScrollPerPixel(settings.value(QStringLiteral("ScrollPerPixel"), true).toBool());
+    dlg_->setShowThumbnails(settings.value("ShowThumbnails"_L1, true).toBool());
+    dlg_->setNoItemTooltip(settings.value("NoItemTooltip"_L1, false).toBool());
+    dlg_->setScrollPerPixel(settings.value("ScrollPerPixel"_L1, true).toBool());
 
-    dlg_->setBigIconSize(settings.value(QStringLiteral("BigIconSize"), 48).toInt());
-    dlg_->setSmallIconSize(settings.value(QStringLiteral("SmallIconSize"), 24).toInt());
-    dlg_->setThumbnailIconSize(settings.value(QStringLiteral("ThumbnailIconSize"), 128).toInt());
+    dlg_->setBigIconSize(settings.value("BigIconSize"_L1, 48).toInt());
+    dlg_->setSmallIconSize(settings.value("SmallIconSize"_L1, 24).toInt());
+    dlg_->setThumbnailIconSize(settings.value("ThumbnailIconSize"_L1, 128).toInt());
 
-    const QList<QVariant> hiddenColumns = settings.value(QStringLiteral("HiddenColumns")).toList();
+    const QList<QVariant> hiddenColumns = settings.value("HiddenColumns"_L1).toList();
     QList<int> l;
     for(auto width : hiddenColumns) {
         l << width.toInt();
@@ -329,8 +331,8 @@ void FileDialogHelper::loadSettings() {
     dlg_->setHiddenColumns(l);
     settings.endGroup();
 
-    settings.beginGroup(QStringLiteral("Places"));
-    QStringList hiddenPlacesList = settings.value(QStringLiteral("HiddenPlaces")).toStringList();
+    settings.beginGroup("Places"_L1);
+    QStringList hiddenPlacesList = settings.value("HiddenPlaces"_L1).toStringList();
     QSet<QString> hiddenPlacesSet = QSet<QString>(hiddenPlacesList.begin(), hiddenPlacesList.end());
     dlg_->setHiddenPlaces(hiddenPlacesSet);
     settings.endGroup();
@@ -338,72 +340,72 @@ void FileDialogHelper::loadSettings() {
 
 // This also prevents redundant writings whenever a file dialog is closed without a change in its settings.
 void FileDialogHelper::saveSettings() {
-    QSettings settings(QSettings::UserScope, QStringLiteral("lxqt"), QStringLiteral("filedialog"));
-    settings.beginGroup (QStringLiteral("Sizes"));
+    QSettings settings(QSettings::UserScope, "lxqt"_L1, "filedialog"_L1);
+    settings.beginGroup ("Sizes"_L1);
     QSize windowSize = dlg_->size();
-    if(settings.value(QStringLiteral("WindowSize")) != windowSize) { // no redundant write
-        settings.setValue(QStringLiteral("WindowSize"), windowSize);
+    if(settings.value("WindowSize"_L1) != windowSize) { // no redundant write
+        settings.setValue("WindowSize"_L1, windowSize);
     }
     int splitterPos = dlg_->splitterPos();
-    if(settings.value(QStringLiteral("SplitterPos")) != splitterPos) {
-        settings.setValue(QStringLiteral("SplitterPos"), splitterPos);
+    if(settings.value("SplitterPos"_L1) != splitterPos) {
+        settings.setValue("SplitterPos"_L1, splitterPos);
     }
     settings.endGroup();
 
-    settings.beginGroup (QStringLiteral("View"));
+    settings.beginGroup ("View"_L1);
     QString mode = viewModeToString(dlg_->viewMode());
-    if(settings.value(QStringLiteral("Mode")) != mode) {
-        settings.setValue(QStringLiteral("Mode"), mode);
+    if(settings.value("Mode"_L1) != mode) {
+        settings.setValue("Mode"_L1, mode);
     }
     QString sortColumn = sortColumnToString(static_cast<Fm::FolderModel::ColumnId>(dlg_->sortColumn()));
-    if(settings.value(QStringLiteral("SortColumn")) != sortColumn) {
-        settings.setValue(QStringLiteral("SortColumn"), sortColumn);
+    if(settings.value("SortColumn"_L1) != sortColumn) {
+        settings.setValue("SortColumn"_L1, sortColumn);
     }
     QString sortOrder = sortOrderToString(dlg_->sortOrder());
-    if(settings.value(QStringLiteral("SortOrder")) != sortOrder) {
-        settings.setValue(QStringLiteral("SortOrder"), sortOrder);
+    if(settings.value("SortOrder"_L1) != sortOrder) {
+        settings.setValue("SortOrder"_L1, sortOrder);
     }
     bool sortFolderFirst = dlg_->sortFolderFirst();
-    if(settings.value(QStringLiteral("SortFolderFirst")).toBool() != sortFolderFirst) {
-        settings.setValue(QStringLiteral("SortFolderFirst"), sortFolderFirst);
+    if(settings.value("SortFolderFirst"_L1).toBool() != sortFolderFirst) {
+        settings.setValue("SortFolderFirst"_L1, sortFolderFirst);
     }
     bool sortHiddenLast = dlg_->sortHiddenLast();
-    if(settings.value(QStringLiteral("SortHiddenLast")).toBool() != sortHiddenLast) {
-        settings.setValue(QStringLiteral("SortHiddenLast"), sortHiddenLast);
+    if(settings.value("SortHiddenLast"_L1).toBool() != sortHiddenLast) {
+        settings.setValue("SortHiddenLast"_L1, sortHiddenLast);
     }
     bool sortCaseSensitive = dlg_->sortCaseSensitive();
-    if(settings.value(QStringLiteral("SortCaseSensitive")).toBool() != sortCaseSensitive) {
-        settings.setValue(QStringLiteral("SortCaseSensitive"), sortCaseSensitive);
+    if(settings.value("SortCaseSensitive"_L1).toBool() != sortCaseSensitive) {
+        settings.setValue("SortCaseSensitive"_L1, sortCaseSensitive);
     }
     bool showHidden = dlg_->showHidden();
-    if(settings.value(QStringLiteral("ShowHidden")).toBool() != showHidden) {
-        settings.setValue(QStringLiteral("ShowHidden"), showHidden);
+    if(settings.value("ShowHidden"_L1).toBool() != showHidden) {
+        settings.setValue("ShowHidden"_L1, showHidden);
     }
 
     bool showThumbnails = dlg_->showThumbnails();
-    if(settings.value(QStringLiteral("ShowThumbnails")).toBool() != showThumbnails) {
-        settings.setValue(QStringLiteral("ShowThumbnails"), showThumbnails);
+    if(settings.value("ShowThumbnails"_L1).toBool() != showThumbnails) {
+        settings.setValue("ShowThumbnails"_L1, showThumbnails);
     }
     bool noItemTooltip = dlg_->noItemTooltip();
-    if(settings.value(QStringLiteral("NoItemTooltip")).toBool() != noItemTooltip) {
-        settings.setValue(QStringLiteral("NoItemTooltip"), noItemTooltip);
+    if(settings.value("NoItemTooltip"_L1).toBool() != noItemTooltip) {
+        settings.setValue("NoItemTooltip"_L1, noItemTooltip);
     }
     bool scrollPerPixel = dlg_->scrollPerPixel();
-    if(settings.value(QStringLiteral("ScrollPerPixel")).toBool() != scrollPerPixel) {
-        settings.setValue(QStringLiteral("ScrollPerPixel"), scrollPerPixel);
+    if(settings.value("ScrollPerPixel"_L1).toBool() != scrollPerPixel) {
+        settings.setValue("ScrollPerPixel"_L1, scrollPerPixel);
     }
 
     int size = dlg_->bigIconSize();
-    if(settings.value(QStringLiteral("BigIconSize")).toInt() != size) {
-        settings.setValue(QStringLiteral("BigIconSize"), size);
+    if(settings.value("BigIconSize"_L1).toInt() != size) {
+        settings.setValue("BigIconSize"_L1, size);
     }
     size = dlg_->smallIconSize();
-    if(settings.value(QStringLiteral("SmallIconSize")).toInt() != size) {
-        settings.setValue(QStringLiteral("SmallIconSize"), size);
+    if(settings.value("SmallIconSize"_L1).toInt() != size) {
+        settings.setValue("SmallIconSize"_L1, size);
     }
     size = dlg_->thumbnailIconSize();
-    if(settings.value(QStringLiteral("ThumbnailIconSize")).toInt() != size) {
-        settings.setValue(QStringLiteral("ThumbnailIconSize"), size);
+    if(settings.value("ThumbnailIconSize"_L1).toInt() != size) {
+        settings.setValue("ThumbnailIconSize"_L1, size);
     }
 
     QList<int> columns = dlg_->getHiddenColumns();
@@ -412,22 +414,22 @@ void FileDialogHelper::saveSettings() {
     for(int i = 0; i < columns.size(); ++i) {
         hiddenColumns << QVariant(columns.at(i));
     }
-    if(settings.value(QStringLiteral("HiddenColumns")).toList() != hiddenColumns) {
-        settings.setValue(QStringLiteral("HiddenColumns"), hiddenColumns);
+    if(settings.value("HiddenColumns"_L1).toList() != hiddenColumns) {
+        settings.setValue("HiddenColumns"_L1, hiddenColumns);
     }
     settings.endGroup();
 
-    settings.beginGroup(QStringLiteral("Places"));
+    settings.beginGroup("Places"_L1);
     QSet<QString> hiddenPlaces = dlg_->getHiddenPlaces();
     if(hiddenPlaces.isEmpty()) { // don't save "@Invalid()"
-        settings.remove(QStringLiteral("HiddenPlaces"));
+        settings.remove("HiddenPlaces"_L1);
     }
     else {
-        QStringList hiddenPlacesList = settings.value(QStringLiteral("HiddenPlaces")).toStringList();
+        QStringList hiddenPlacesList = settings.value("HiddenPlaces"_L1).toStringList();
         QSet<QString> hiddenPlacesSet = QSet<QString>(hiddenPlacesList.begin(), hiddenPlacesList.end());
         if (hiddenPlaces != hiddenPlacesSet) {
             QStringList sl(hiddenPlaces.begin(), hiddenPlaces.end());
-            settings.setValue(QStringLiteral("HiddenPlaces"), sl);
+            settings.setValue("HiddenPlaces"_L1, sl);
         }
     }
     settings.endGroup();

--- a/src/filepropsdialog.cpp
+++ b/src/filepropsdialog.cpp
@@ -39,6 +39,8 @@
 #define DIFFERENT_GIDS    ((gid)-1)
 #define DIFFERENT_PERMS   ((mode_t)-1)
 
+using namespace Qt::Literals::StringLiterals;
+
 namespace Fm {
 
 enum {
@@ -159,7 +161,7 @@ void FilePropsDialog::initPermissionsPage() {
     // Let's make it clear for the users
     // init combo boxes for file permissions here
     QStringList comboItems;
-    comboItems.append(QStringLiteral("---")); // no change
+    comboItems.append(u"---"_s); // no change
     if(singleType && hasDir) { // all files are dirs
         comboItems.append(tr("View folder content"));
         comboItems.append(tr("View and modify folder content"));
@@ -439,12 +441,12 @@ void FilePropsDialog::onFileSizeTimerTimeout() {
         // they use unsigned long instead of int.
         // We cannot use Qt here to handle plural forms. So sad. :-(
         QString str = Fm::formatFileSize(totalSizeJob->totalSize(), fm_config->si_unit) %
-                      QStringLiteral(" (%1 B)").arg(totalSizeJob->totalSize());
+                      u" (%1 B)"_s.arg(totalSizeJob->totalSize());
         // tr(" (%n) byte(s)", "", deepCountJob->total_size);
         ui->fileSize->setText(str);
 
         str = Fm::formatFileSize(totalSizeJob->totalOnDiskSize(), fm_config->si_unit) %
-              QStringLiteral(" (%1 B)").arg(totalSizeJob->totalOnDiskSize());
+              u" (%1 B)"_s.arg(totalSizeJob->totalOnDiskSize());
         // tr(" (%n) byte(s)", "", deepCountJob->total_ondisk_size);
         ui->onDiskSize->setText(str);
 
@@ -465,13 +467,13 @@ void FilePropsDialog::onIconButtonclicked() {
     QString iconDir;
     QString iconThemeName = QIcon::themeName();
     QStringList icons = QStandardPaths::locateAll(QStandardPaths::GenericDataLocation,
-                                                  QStringLiteral("icons"),
+                                                  u"icons"_s,
                                                   QStandardPaths::LocateDirectory);
     for (QStringList::ConstIterator it = icons.constBegin(); it != icons.constEnd(); ++it) {
-        QString iconThemeFolder = *it + QLatin1String("/") + iconThemeName;
+        QString iconThemeFolder = *it + "/"_L1 + iconThemeName;
         if (QDir(iconThemeFolder).exists() && QFileInfo(iconThemeFolder).permission(QFileDevice::ReadUser)) {
             // give priority to the "places" folder
-            const QString places = iconThemeFolder + QLatin1String("/places");
+            const QString places = iconThemeFolder + "/places"_L1;
             if (QDir(places).exists() && QFileInfo(places).permission(QFileDevice::ReadUser)) {
                 iconDir = places;
             }
@@ -483,7 +485,7 @@ void FilePropsDialog::onIconButtonclicked() {
     }
     if(iconDir.isEmpty()) {
         iconDir = QStandardPaths::locate(QStandardPaths::GenericDataLocation,
-                                         QStringLiteral("icons"),
+                                         u"icons"_s,
                                          QStandardPaths::LocateDirectory);
         if(iconDir.isEmpty()) {
             return;
@@ -493,10 +495,10 @@ void FilePropsDialog::onIconButtonclicked() {
                                                           iconDir,
                                                           tr("Images (*.png *.xpm *.svg *.svgz )"));
     if(!iconPath.isEmpty()) {
-        QStringList parts = iconPath.split(QStringLiteral("/"), Qt::SkipEmptyParts);
+        QStringList parts = iconPath.split(u"/"_s, Qt::SkipEmptyParts);
         if(!parts.isEmpty()) {
             QString iconName = parts.at(parts.count() - 1);
-            int ln = iconName.lastIndexOf(QLatin1String("."));
+            int ln = iconName.lastIndexOf("."_L1);
             if(ln > -1) {
                 iconName.remove(ln, iconName.length() - ln);
                 customIcon = QIcon::fromTheme(iconName);
@@ -510,13 +512,13 @@ void FilePropsDialog::onEmblemButtonclicked() {
     QString iconDir;
     QString iconThemeName = QIcon::themeName();
     QStringList icons = QStandardPaths::locateAll(QStandardPaths::GenericDataLocation,
-                                                  QStringLiteral("icons"),
+                                                  u"icons"_s,
                                                   QStandardPaths::LocateDirectory);
     for (QStringList::ConstIterator it = icons.constBegin(); it != icons.constEnd(); ++it) {
-        QString iconThemeFolder = *it + QLatin1String("/") + iconThemeName;
+        QString iconThemeFolder = *it + "/"_L1 + iconThemeName;
         if (QDir(iconThemeFolder).exists() && QFileInfo(iconThemeFolder).permission(QFileDevice::ReadUser)) {
             // give priority to the "emblems" folder
-            const QString emblems = iconThemeFolder + QLatin1String("/emblems");
+            const QString emblems = iconThemeFolder + "/emblems"_L1;
             if (QDir(emblems).exists() && QFileInfo(emblems).permission(QFileDevice::ReadUser)) {
                 iconDir = emblems;
             }
@@ -528,7 +530,7 @@ void FilePropsDialog::onEmblemButtonclicked() {
     }
     if(iconDir.isEmpty()) {
         iconDir = QStandardPaths::locate(QStandardPaths::GenericDataLocation,
-                                         QStringLiteral("icons"),
+                                         u"icons"_s,
                                          QStandardPaths::LocateDirectory);
         if(iconDir.isEmpty()) {
             return;
@@ -538,10 +540,10 @@ void FilePropsDialog::onEmblemButtonclicked() {
                                                           iconDir,
                                                           tr("Images (*.png *.xpm *.svg *.svgz )"));
     if(!iconPath.isEmpty()) {
-        QStringList parts = iconPath.split(QStringLiteral("/"), Qt::SkipEmptyParts);
+        QStringList parts = iconPath.split(u"/"_s, Qt::SkipEmptyParts);
         if(!parts.isEmpty()) {
             QString iconName = parts.at(parts.count() - 1);
-            int ln = iconName.lastIndexOf(QLatin1String("."));
+            int ln = iconName.lastIndexOf("."_L1);
             if(ln > -1) {
                 iconName.remove(ln, iconName.length() - ln);
                 auto emblemIcon = QIcon::fromTheme(iconName);
@@ -555,7 +557,7 @@ void FilePropsDialog::onEmblemButtonclicked() {
 }
 
 void FilePropsDialog::onClearEmblemButtonclicked() {
-    ui->emblemButton->setText(QStringLiteral("..."));
+    ui->emblemButton->setText(u"..."_s);
     // to show that the emblem should be removed
     ui->emblemButton->setIcon(QIcon());
     ui->emblemButton->setToolButtonStyle(Qt::ToolButtonTextOnly);

--- a/src/filesearchdialog.cpp
+++ b/src/filesearchdialog.cpp
@@ -71,7 +71,7 @@ QString FileSearchDialog::contentPattern() const {
 void FileSearchDialog::addNamePatterns(const QStringList& patterns) {
     ui->namePatterns->addItems(patterns);
     ui->namePatterns->setCurrentIndex(-1);
-    ui->namePatterns->setCurrentText(QLatin1String("*"));
+    ui->namePatterns->setCurrentText(QStringLiteral("*"));
 }
 
 void FileSearchDialog::addContentPatterns(const QStringList& patterns) {

--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -474,24 +474,24 @@ void FolderItemDelegate::setEditorData(QWidget* editor, const QModelIndex& index
         // select text appropriately
         QTextCursor cur = textEdit->textCursor();
         int end;
-        if (index.data(Fm::FolderModel::FileIsDirRole).toBool() || !currentName.contains(QLatin1String("."))) {
+        if (index.data(Fm::FolderModel::FileIsDirRole).toBool() || !currentName.contains(QLatin1StringView("."))) {
             end = currentName.size();
         }
         else {
-            end = currentName.lastIndexOf(QLatin1String("."));
+            end = currentName.lastIndexOf(QLatin1StringView("."));
         }
         cur.setPosition(end, QTextCursor::KeepAnchor);
         textEdit->setTextCursor(cur);
     }
     else if (QLineEdit* lineEdit = qobject_cast<QLineEdit*>(editor)) {
         lineEdit->setText(currentName);
-        if (!index.data(Fm::FolderModel::FileIsDirRole).toBool() && currentName.contains(QLatin1String(".")))
+        if (!index.data(Fm::FolderModel::FileIsDirRole).toBool() && currentName.contains(QLatin1StringView(".")))
         {
             /* Qt will call QLineEdit::selectAll() after calling setEditorData() in
                qabstractitemview.cpp -> QAbstractItemViewPrivate::editor(). Therefore,
                we cannot select a part of the text in the usual way here.  */
             QTimer::singleShot(0, lineEdit, [lineEdit]() {
-                int length = lineEdit->text().lastIndexOf(QLatin1String("."));
+                int length = lineEdit->text().lastIndexOf(QLatin1StringView("."));
                 lineEdit->setSelection(0, length);
             });
         }

--- a/src/fontbutton.cpp
+++ b/src/fontbutton.cpp
@@ -42,11 +42,11 @@ void FontButton::setFont(QFont font) {
     font_ = font;
     QString text = font.family();
     if(font.bold()) {
-        text += QLatin1String(" ");
+        text += QLatin1StringView(" ");
         text += tr("Bold");
     }
     if(font.italic()) {
-        text += QLatin1String(" ");
+        text += QLatin1StringView(" ");
         text += tr("Italic");
     }
     text += QStringLiteral(" %1").arg(font.pointSize());

--- a/src/libfmqt.cpp
+++ b/src/libfmqt.cpp
@@ -61,7 +61,7 @@ LibFmQtData::LibFmQtData(): refCount(1) {
     // turn on glib debug message
     // g_setenv("G_MESSAGES_DEBUG", "all", true);
     Fm::Thumbnailer::loadAll();
-    (void)translator.load(QLatin1String("libfm-qt_") + QLocale::system().name(), QLatin1String(LIBFM_QT_DATA_DIR) + QLatin1String("/translations"));
+    (void)translator.load(QStringLiteral("libfm-qt_") + QLocale::system().name(), QStringLiteral(LIBFM_QT_DATA_DIR) + QStringLiteral("/translations"));
 
     // FIXME: we keep the FmConfig data structure here to keep compatibility with legacy libfm API.
     fm_config_init();

--- a/src/mountoperationpassworddialog.cpp
+++ b/src/mountoperationpassworddialog.cpp
@@ -42,11 +42,11 @@ MountOperationPasswordDialog::MountOperationPasswordDialog(MountOperation* op, G
     ui->buttonBox->buttons().constFirst()->setText(tr("&Connect"));
     connect(ui->Anonymous, &QAbstractButton::toggled, this, &MountOperationPasswordDialog::onAnonymousToggled);
 
-    QSettings settings(QSettings::UserScope, QStringLiteral("lxqt"), QStringLiteral("mountdialog"));
+    QSettings settings(QSettings::UserScope, QLatin1StringView("lxqt"), QLatin1StringView("mountdialog"));
 
     if(canAnonymous) {
         // select ananymous by default if applicable.
-        if(settings.value(QStringLiteral("Anonymous"), true).toBool()) {
+        if(settings.value(QLatin1StringView("Anonymous"), true).toBool()) {
             ui->Anonymous->setChecked(true);
         }
         else {
@@ -54,8 +54,8 @@ MountOperationPasswordDialog::MountOperationPasswordDialog(MountOperation* op, G
         }
         connect(ui->usernameGroup, &QButtonGroup::buttonToggled, this, [this](QAbstractButton *btn, bool checked) {
             if(checked) {
-                QSettings settings(QSettings::UserScope, QStringLiteral("lxqt"), QStringLiteral("mountdialog"));
-                settings.setValue(QStringLiteral("Anonymous"), btn == ui->Anonymous);
+                QSettings settings(QSettings::UserScope, QLatin1StringView("lxqt"), QLatin1StringView("mountdialog"));
+                settings.setValue(QLatin1StringView("Anonymous"), btn == ui->Anonymous);
             }
         });
     }
@@ -79,7 +79,7 @@ MountOperationPasswordDialog::MountOperationPasswordDialog(MountOperation* op, G
         ui->domainLabel->hide();
     }
     if(canSavePassword) {
-        switch(settings.value(QStringLiteral("RememberPassword"), 0).toInt()) {
+        switch(settings.value(QLatin1StringView("RememberPassword"), 0).toInt()) {
         case -1:
             ui->forgetPassword->setChecked(true);
             break;
@@ -93,8 +93,8 @@ MountOperationPasswordDialog::MountOperationPasswordDialog(MountOperation* op, G
         connect(ui->passwordGroup, &QButtonGroup::buttonToggled, this, [this](QAbstractButton *btn, bool checked) {
             if(checked) {
                 int remember = (btn == ui->forgetPassword ? -1 : btn == ui->storePassword ? 1 : 0);
-                QSettings settings(QSettings::UserScope, QStringLiteral("lxqt"), QStringLiteral("mountdialog"));
-                settings.setValue(QStringLiteral("RememberPassword"), remember);
+                QSettings settings(QSettings::UserScope, QLatin1StringView("lxqt"), QLatin1StringView("mountdialog"));
+                settings.setValue(QLatin1StringView("RememberPassword"), remember);
             }
         });
     }

--- a/src/pathbar.cpp
+++ b/src/pathbar.cpp
@@ -292,7 +292,7 @@ void PathBar::setPath(Fm::FilePath path) {
             name = pathStr.toStdString();
         }
         // double ampersands to distinguish them from mnemonics
-        displayName.replace(QLatin1Char('&'), QLatin1String("&&"));
+        displayName.replace(QLatin1Char('&'), QLatin1StringView("&&"));
         auto btn = new PathButton(name, displayName, isRoot, buttonsWidget_);
         btn->show();
         connect(btn, &QAbstractButton::toggled, this, &PathBar::onButtonToggled);

--- a/src/pathedit.cpp
+++ b/src/pathedit.cpp
@@ -48,7 +48,7 @@ void PathEditJob::runJob() {
                 if(type == G_FILE_TYPE_DIRECTORY) {
                     const char* name = g_file_info_get_display_name(inf);
                     // FIXME: encoding conversion here?
-                    subDirs.append(QString::fromUtf8(name) + QLatin1String("/"));
+                    subDirs.append(QString::fromUtf8(name) + QLatin1StringView("/"));
                 }
                 g_object_unref(inf);
             }
@@ -192,7 +192,7 @@ void PathEdit::selectNextCompletionRow(bool downward) {
 
 void PathEdit::onTextEdited(const QString& text) {
     // just replace start tilde with home path if text is changed by user
-    if(text == QLatin1String("~") || text.startsWith(QLatin1String("~/"))) {
+    if(text == QLatin1StringView("~") || text.startsWith(QLatin1StringView("~/"))) {
         QString txt(text);
         txt.replace(0, 1, QDir::homePath());
         lastTypedText_ = txt;
@@ -203,7 +203,7 @@ void PathEdit::onTextEdited(const QString& text) {
 }
 
 void PathEdit::onTextChanged(const QString& text) {
-    if(text == QLatin1String("~") || text.startsWith(QLatin1String("~/"))) {
+    if(text == QLatin1StringView("~") || text.startsWith(QLatin1StringView("~/"))) {
         // do nothing with a start tilde because neither Fm::FilePath nor autocompletion
         // understands it; instead, wait until textChanged() is emitted again without it
         // WARNING: replacing tilde may not be safe here

--- a/src/placesmodelitem.cpp
+++ b/src/placesmodelitem.cpp
@@ -125,16 +125,16 @@ void PlacesModelVolumeItem::update() {
         setPath(Fm::FilePath{});
         if(CStrPtr identifier{g_volume_get_identifier(volume_, G_VOLUME_IDENTIFIER_KIND_UNIX_DEVICE)}) {
             toolTip = QObject::tr("Identifier: ");
-            toolTip += QLatin1String(identifier.get());
+            toolTip += QLatin1StringView(identifier.get());
         }
         if(CStrPtr uuid{g_volume_get_uuid(volume_)}) {
             if(toolTip.isEmpty()) {
-                toolTip = QLatin1String("UUID: ");
+                toolTip = QLatin1StringView("UUID: ");
             }
             else {
-                toolTip += QLatin1String("\nUUID: ");
+                toolTip += QLatin1StringView("\nUUID: ");
             }
-            toolTip += QLatin1String(uuid.get());
+            toolTip += QLatin1StringView(uuid.get());
         }
     }
 

--- a/src/placesview.cpp
+++ b/src/placesview.cpp
@@ -571,7 +571,7 @@ void PlacesView::contextMenuEvent(QContextMenuEvent* event) {
                 if(strcmp(path_str.get(), "trash:///") == 0) {
                     action = new PlacesModel::ItemAction(item->index(), tr("Empty Trash"), menu);
                     auto icn = item->icon();
-                    if(icn && icn->qicon().name() == QLatin1String("user-trash")) { // surely an empty trash
+                    if(icn && icn->qicon().name() == QLatin1StringView("user-trash")) { // surely an empty trash
                         action->setEnabled(false);
                     }
                     else {


### PR DESCRIPTION
`QLatin1StringView` is used instead of `QLatin1String`.

Also, instead of `QLatin1StringView` and `QStringLiteral`, the operators `_L1` and `_s` are used respectively when a source file contains many string literals. This is supported since Qt 6.4 and makes codes more readable as well as easier to write.

NOTE: This may seem like a heavy patch, but the changes should be made sooner or later — also in other sources. Here I preferred sooner rather than later. Will do it for pcmanfm-qt too.