### PR TITLE
Enabled custom options for local terminals list

### DIFF
--- a/src/core/terminal.cpp
+++ b/src/core/terminal.cpp
@@ -19,27 +19,39 @@ static void child_setup(gpointer user_data) {
 }
 
 bool launchTerminal(const char* programName, const FilePath& workingDir, Fm::GErrorPtr& error) {
-    /* read user and system terminals files */
+    CStrPtr desktop_id;
+    CStrPtr launch;
+    CStrPtr custom_args;
+
+    /* read local and global terminals lists */
     GKeyFile* kf = g_key_file_new();
-    bool found = g_key_file_load_from_data_dirs(kf, "libfm-qt/terminals.list", nullptr, G_KEY_FILE_NONE, nullptr);
-    if(found) {
-        found = g_key_file_has_group(kf, programName);
+    if(g_key_file_load_from_data_dirs(kf, "libfm-qt/terminals.list", nullptr, G_KEY_FILE_NONE, nullptr)
+       && g_key_file_has_group(kf, programName)) {
+        desktop_id = CStrPtr{g_key_file_get_string(kf, programName, "desktop_id", nullptr)};
+        launch = CStrPtr{g_key_file_get_string(kf, programName, "launch", nullptr)};
+        /* read only from the local list */
+        custom_args = CStrPtr{g_key_file_get_string(kf, programName, "custom_args", nullptr)};
     }
-    if(!found) {
+    if (!desktop_id || !launch // file or key did not exist
+        // value did not exist
+        || g_strcmp0(desktop_id.get(), "") == 0 || g_strcmp0(launch.get(), "") == 0) {
         g_key_file_free(kf);
         kf = g_key_file_new();
-        if(!g_key_file_load_from_file(kf, LIBFM_QT_DATA_DIR "/terminals.list", G_KEY_FILE_NONE, &error)) {
-            g_key_file_free(kf);
-            return false;
+        if(g_key_file_load_from_file(kf, LIBFM_QT_DATA_DIR "/terminals.list", G_KEY_FILE_NONE, &error)
+           && g_key_file_has_group(kf, programName)) {
+            if (!desktop_id || g_strcmp0(desktop_id.get(), "") == 0) {
+                desktop_id = CStrPtr{g_key_file_get_string(kf, programName, "desktop_id", nullptr)};
+            }
+            if (!launch || g_strcmp0(launch.get(), "") == 0) {
+                launch = CStrPtr{g_key_file_get_string(kf, programName, "launch", nullptr)};
+            }
         }
     }
-
-    auto launch = g_key_file_get_string(kf, programName, "launch", nullptr);
-    auto desktop_id = g_key_file_get_string(kf, programName, "desktop_id", nullptr);
+    g_key_file_free(kf);
 
     GDesktopAppInfo* appinfo = nullptr;
-    if(desktop_id) {
-        appinfo = g_desktop_app_info_new(desktop_id);
+    if(desktop_id && g_strcmp0(desktop_id.get(), "") != 0) {
+        appinfo = g_desktop_app_info_new(desktop_id.get());
     }
 
     const gchar* cmd;
@@ -47,20 +59,18 @@ bool launchTerminal(const char* programName, const FilePath& workingDir, Fm::GEr
     if(appinfo) {
         cmd = g_app_info_get_commandline(G_APP_INFO(appinfo));
     }
-    else if(launch) {
-        cmd = _cmd = g_strdup_printf("%s %s", programName, launch);
+    else if(launch && g_strcmp0(launch.get(), "") != 0) {
+        cmd = _cmd = g_strdup_printf("%s %s", programName, launch.get());
     }
     else {
         cmd = programName;
     }
 
-#if 0 // FIXME: what's this?
-    if(custom_args) {
-        cmd = g_strdup_printf("%s %s", cmd, custom_args);
+    if(custom_args && g_strcmp0(custom_args.get(), "") != 0) {
+        cmd = g_strdup_printf("%s %s", cmd, custom_args.get());
         g_free(_cmd);
         _cmd = (char*)cmd;
     }
-#endif
 
     char** argv;
     int argc;
@@ -115,8 +125,23 @@ bool launchTerminal(const char* programName, const FilePath& workingDir, Fm::GEr
                              nullptr, &error);
     g_strfreev(argv);
     g_strfreev(envp);
-    g_key_file_free(kf);
     return ret;
+}
+
+std::vector<CStrPtr> internalTerminals() {
+    std::vector<CStrPtr> terminals;
+    GKeyFile* kf = g_key_file_new();
+    if(g_key_file_load_from_file(kf, LIBFM_QT_DATA_DIR "/terminals.list", G_KEY_FILE_NONE, nullptr)) {
+        gsize n;
+        auto programs = g_key_file_get_groups(kf, &n);
+        terminals.reserve(terminals.capacity() + n);
+        for(auto name = programs; *name; ++name) {
+            terminals.emplace_back(*name);
+        }
+        g_free(programs);
+    }
+    g_key_file_free(kf);
+    return terminals;
 }
 
 std::vector<CStrPtr> allKnownTerminals() {
@@ -157,28 +182,38 @@ extern "C" char* expand_terminal(char* cmd, gboolean keep_open, GError** error) 
     CStrPtr noclose_arg;
     CStrPtr custom_args;
 
-    /* read user and system terminals files */
-    bool found = false;
+    /* read local and global terminals lists */
     GKeyFile* kf = g_key_file_new();
-    if(g_key_file_load_from_data_dirs(kf, "libfm-qt/terminals.list", nullptr, G_KEY_FILE_NONE, nullptr)) {
-        found = g_key_file_has_group(kf, defaultTerminalName.c_str());
-    }
-    if(!found) {
-        g_key_file_free(kf);
-        kf = g_key_file_new();
-        if(g_key_file_load_from_file(kf, LIBFM_QT_DATA_DIR "/terminals.list", G_KEY_FILE_NONE, error)) {
-            found = g_key_file_has_group(kf, defaultTerminalName.c_str());
-        }
-    }
-    if(found) {
+    if(g_key_file_load_from_data_dirs(kf, "libfm-qt/terminals.list", nullptr, G_KEY_FILE_NONE, nullptr)
+       && g_key_file_has_group(kf, defaultTerminalName.c_str())) {
         program = defaultTerminalName.c_str();
         open_arg = CStrPtr{g_key_file_get_string(kf, program, "open_arg", nullptr)};
         noclose_arg = CStrPtr{g_key_file_get_string(kf, program, "noclose_arg", nullptr)};
         custom_args = CStrPtr{g_key_file_get_string(kf, program, "custom_args", nullptr)};
+        /* NOTE: "custom_args" is read only from the local list, but if "open_arg" or
+           "noclose_arg" is missing in the local list, it will be read from the global list. */
+    }
+    if(!open_arg || !noclose_arg // file or key did not exist
+       // value did not exist
+       || g_strcmp0(open_arg.get(), "") == 0 || g_strcmp0(noclose_arg.get(), "") == 0) {
+        g_key_file_free(kf);
+        kf = g_key_file_new();
+        if(g_key_file_load_from_file(kf, LIBFM_QT_DATA_DIR "/terminals.list", G_KEY_FILE_NONE, error)
+           && g_key_file_has_group(kf, defaultTerminalName.c_str())) {
+            if(!program) {
+                program = defaultTerminalName.c_str();
+            }
+            if(!open_arg || g_strcmp0(open_arg.get(), "") == 0) {
+                open_arg = CStrPtr{g_key_file_get_string(kf, program, "open_arg", nullptr)};
+            }
+            if(!noclose_arg || g_strcmp0(noclose_arg.get(), "") == 0) {
+                noclose_arg = CStrPtr{g_key_file_get_string(kf, program, "noclose_arg", nullptr)};
+            }
+        }
     }
     g_key_file_free(kf);
 
-    const char* opts;
+    const char* opts = nullptr;
     /* if %s is not found, fallback to -e */
     /* bug #3457335: Crash on application start with Terminal=true. */
     /* fallback to xterm if a terminal emulator is not found. */
@@ -190,9 +225,9 @@ extern "C" char* expand_terminal(char* cmd, gboolean keep_open, GError** error) 
         open_arg = CStrPtr{g_strdup("-e")};
     }
 
-    if(keep_open && noclose_arg)
+    if(keep_open && noclose_arg && g_strcmp0(noclose_arg.get(), "") != 0)
         opts = noclose_arg.get();
-    else
+    else if (open_arg && g_strcmp0(open_arg.get(), "") != 0)
         opts = open_arg.get();
 
     if(!opts) {
@@ -201,7 +236,7 @@ extern "C" char* expand_terminal(char* cmd, gboolean keep_open, GError** error) 
     }
 
     char* ret = nullptr;
-    if(custom_args)
+    if(custom_args && g_strcmp0(custom_args.get(), "") != 0)
         ret = g_strdup_printf("%s %s %s %s", program, custom_args.get(),
                               opts, cmd);
     else

--- a/src/core/terminal.h
+++ b/src/core/terminal.h
@@ -11,6 +11,8 @@ namespace Fm {
 
 LIBFM_QT_API bool launchTerminal(const char* programName, const FilePath& workingDir, GErrorPtr& error);
 
+LIBFM_QT_API std::vector<CStrPtr> internalTerminals();
+
 LIBFM_QT_API std::vector<CStrPtr> allKnownTerminals();
 
 LIBFM_QT_API const std::string defaultTerminal();


### PR DESCRIPTION
The `custom_args` key is read only from the local list (the global list doesn't — and shouldn't — have it), while `open_arg` and `noclose_arg` are first read from the local list, and if empty, from the global list.

Also, a memory leak and a bug are fixed in `terminal.cpp`.

Closes https://github.com/lxqt/libfm-qt/issues/954

NOTE: This PR will be followed by a pcmanfm-qt PR that uses it.