### PR TITLE
Try better to change directory on mounting by clicking in side-pane

### DIFF
--- a/src/placesmodel.cpp
+++ b/src/placesmodel.cpp
@@ -351,14 +351,16 @@ void PlacesModel::onMountAdded(GVolumeMonitor* /*monitor*/, GMount* mount, Place
     GVolume* vol = g_mount_get_volume(mount);
     if(vol) { // mount-added is also emitted when a volume is newly mounted.
         PlacesModelVolumeItem* item = pThis->itemFromVolume(vol);
-        if(item && !item->path()) {
-            // update the mounted volume and show a button for eject.
-            Fm::FilePath path{g_mount_get_root(mount), false};
-            item->setPath(path);
+        if(item) {
+            if(!item->path()) {
+                // update the mounted volume
+                Fm::FilePath path{g_mount_get_root(mount), false};
+                item->setPath(path);
+            }
             // update the mount indicator (eject button)
-            QStandardItem* ejectBtn = item->parent()->child(item->row(), 1);
-            Q_ASSERT(ejectBtn);
-            ejectBtn->setIcon(pThis->ejectIcon_);
+            if(QStandardItem* ejectBtn = item->parent()->child(item->row(), 1)) {
+                ejectBtn->setIcon(pThis->ejectIcon_);
+            }
         }
         g_object_unref(vol);
     }

--- a/src/placesview.cpp
+++ b/src/placesview.cpp
@@ -238,7 +238,15 @@ void PlacesView::activateRow(int type, const QModelIndex& index) {
                     QTimer::singleShot(0, op, [this, op, type, index] () {
                         if(op->wait()) {
                             if(PlacesModelItem* item = static_cast<PlacesModelItem*>(model_->itemFromIndex(proxyModel_->mapToSource(index)))) {
-                                if(auto path = item->path()) {
+                                auto path = item->path();
+                                if(!path && item->type() == PlacesModelItem::Volume) {
+                                    // If the signal "mount-added" is not emitted at this moment,
+                                    // the path is not set yet. Try to update the item.
+                                    auto volumeItem = static_cast<PlacesModelVolumeItem*>(item);
+                                    volumeItem->update();
+                                    path = volumeItem->path();
+                                }
+                                if(path) {
                                     Q_EMIT chdirRequested(type, path);
                                 }
                             }


### PR DESCRIPTION
Sometimes the signal "mount-changed" is emitted by GIO with a delay when a volume is mounted by activating its side-pane item, and so, the directory isn't changed. This patch is a workaround for such cases.

Closes https://github.com/lxqt/libfm-qt/issues/1031