### PR TITLE
Add colon to remaining label

### DIFF
--- a/src/file-operation-dialog.ui
+++ b/src/file-operation-dialog.ui
@@ -82,7 +82,7 @@
      <item row="3" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
-        <string>Progress</string>
+        <string>Progress:</string>
        </property>
       </widget>
      </item>

--- a/src/translations/libfm-qt.ts
+++ b/src/translations/libfm-qt.ts
@@ -158,7 +158,7 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
+        <source>Progress:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/translations/libfm-qt_ar.ts
+++ b/src/translations/libfm-qt_ar.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>التقدّم</translation>
+        <source>Progress:</source>
+        <translation>التقدّم:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_arn.ts
+++ b/src/translations/libfm-qt_arn.ts
@@ -158,7 +158,7 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
+        <source>Progress:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/translations/libfm-qt_ast.ts
+++ b/src/translations/libfm-qt_ast.ts
@@ -158,7 +158,7 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
+        <source>Progress:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/translations/libfm-qt_bg.ts
+++ b/src/translations/libfm-qt_bg.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Прогрес</translation>
+        <source>Progress:</source>
+        <translation>Прогрес:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_ca.ts
+++ b/src/translations/libfm-qt_ca.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Progrés</translation>
+        <source>Progress:</source>
+        <translation>Progrés:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_cs.ts
+++ b/src/translations/libfm-qt_cs.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Ukazatel průběhu</translation>
+        <source>Progress:</source>
+        <translation>Ukazatel průběhu:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_cy.ts
+++ b/src/translations/libfm-qt_cy.ts
@@ -158,7 +158,7 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
+        <source>Progress:</source>
         <translation></translation>
     </message>
     <message>

--- a/src/translations/libfm-qt_da.ts
+++ b/src/translations/libfm-qt_da.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Fremskridt</translation>
+        <source>Progress:</source>
+        <translation>Fremskridt:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_de.ts
+++ b/src/translations/libfm-qt_de.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Fortschritt</translation>
+        <source>Progress:</source>
+        <translation>Fortschritt:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_el.ts
+++ b/src/translations/libfm-qt_el.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Πρόοδος</translation>
+        <source>Progress:</source>
+        <translation>Πρόοδος:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_en_GB.ts
+++ b/src/translations/libfm-qt_en_GB.ts
@@ -158,7 +158,7 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
+        <source>Progress:</source>
         <translation></translation>
     </message>
     <message>

--- a/src/translations/libfm-qt_es.ts
+++ b/src/translations/libfm-qt_es.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Progreso</translation>
+        <source>Progress:</source>
+        <translation>Progreso:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_et.ts
+++ b/src/translations/libfm-qt_et.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Edenemine</translation>
+        <source>Progress:</source>
+        <translation>Edenemine:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_eu.ts
+++ b/src/translations/libfm-qt_eu.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Aurrerapena</translation>
+        <source>Progress:</source>
+        <translation>Aurrerapena:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_fi.ts
+++ b/src/translations/libfm-qt_fi.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Tilanne</translation>
+        <source>Progress:</source>
+        <translation>Tilanne:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_fr.ts
+++ b/src/translations/libfm-qt_fr.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Progression</translation>
+        <source>Progress:</source>
+        <translation>Progression :</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_fur.ts
+++ b/src/translations/libfm-qt_fur.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Progression</translation>
+        <source>Progress:</source>
+        <translation>Progression:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_gl.ts
+++ b/src/translations/libfm-qt_gl.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>En progreso</translation>
+        <source>Progress:</source>
+        <translation>En progreso:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_he.ts
+++ b/src/translations/libfm-qt_he.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>תהליך</translation>
+        <source>Progress:</source>
+        <translation>תהליך:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_hi.ts
+++ b/src/translations/libfm-qt_hi.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>प्रगति</translation>
+        <source>Progress:</source>
+        <translation>प्रगति:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_hr.ts
+++ b/src/translations/libfm-qt_hr.ts
@@ -165,8 +165,8 @@ za ovu vrstu datoteka</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Napredak</translation>
+        <source>Progress:</source>
+        <translation>Napredak:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_hu.ts
+++ b/src/translations/libfm-qt_hu.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Folyamat</translation>
+        <source>Progress:</source>
+        <translation>Folyamat:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_id.ts
+++ b/src/translations/libfm-qt_id.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Kemajuan</translation>
+        <source>Progress:</source>
+        <translation>Kemajuan:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_ie.ts
+++ b/src/translations/libfm-qt_ie.ts
@@ -158,7 +158,7 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
+        <source>Progress:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/translations/libfm-qt_it.ts
+++ b/src/translations/libfm-qt_it.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Avanzamento</translation>
+        <source>Progress:</source>
+        <translation>Avanzamento:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_ja.ts
+++ b/src/translations/libfm-qt_ja.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>進行状況</translation>
+        <source>Progress:</source>
+        <translation>進行状況:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_ka.ts
+++ b/src/translations/libfm-qt_ka.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>მიმდინარეობა</translation>
+        <source>Progress:</source>
+        <translation>მიმდინარეობა:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_kab.ts
+++ b/src/translations/libfm-qt_kab.ts
@@ -158,7 +158,7 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
+        <source>Progress:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/translations/libfm-qt_kk.ts
+++ b/src/translations/libfm-qt_kk.ts
@@ -164,7 +164,7 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
+        <source>Progress:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/translations/libfm-qt_ko.ts
+++ b/src/translations/libfm-qt_ko.ts
@@ -165,8 +165,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>진행</translation>
+        <source>Progress:</source>
+        <translation>진행:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_lg.ts
+++ b/src/translations/libfm-qt_lg.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>We gutuuse</translation>
+        <source>Progress:</source>
+        <translation>We gutuuse:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_lt.ts
+++ b/src/translations/libfm-qt_lt.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Eiga</translation>
+        <source>Progress:</source>
+        <translation>Eiga:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_lv.ts
+++ b/src/translations/libfm-qt_lv.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Progress</translation>
+        <source>Progress:</source>
+        <translation>Progress:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_nb_NO.ts
+++ b/src/translations/libfm-qt_nb_NO.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Framdrift</translation>
+        <source>Progress:</source>
+        <translation>Framdrift:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_nl.ts
+++ b/src/translations/libfm-qt_nl.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Voortgang</translation>
+        <source>Progress:</source>
+        <translation>Voortgang:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_or.ts
+++ b/src/translations/libfm-qt_or.ts
@@ -158,7 +158,7 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
+        <source>Progress:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/translations/libfm-qt_pa.ts
+++ b/src/translations/libfm-qt_pa.ts
@@ -158,8 +158,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>ਤਰੱਕੀ</translation>
+        <source>Progress:</source>
+        <translation>ਤਰੱਕੀ:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_pl.ts
+++ b/src/translations/libfm-qt_pl.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Postęp</translation>
+        <source>Progress:</source>
+        <translation>Postęp:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_pt.ts
+++ b/src/translations/libfm-qt_pt.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Progresso</translation>
+        <source>Progress:</source>
+        <translation>Progresso:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_pt_BR.ts
+++ b/src/translations/libfm-qt_pt_BR.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Progresso</translation>
+        <source>Progress:</source>
+        <translation>Progresso:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_ru.ts
+++ b/src/translations/libfm-qt_ru.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Прогресс</translation>
+        <source>Progress:</source>
+        <translation>Прогресс:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_si.ts
+++ b/src/translations/libfm-qt_si.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>ප්‍රගතිය</translation>
+        <source>Progress:</source>
+        <translation>ප්‍රගතිය:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_sk.ts
+++ b/src/translations/libfm-qt_sk.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Priebeh</translation>
+        <source>Progress:</source>
+        <translation>Priebeh:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_sl.ts
+++ b/src/translations/libfm-qt_sl.ts
@@ -158,8 +158,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Napredek</translation>
+        <source>Progress:</source>
+        <translation>Napredek:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_tr.ts
+++ b/src/translations/libfm-qt_tr.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>İlerleme</translation>
+        <source>Progress:</source>
+        <translation>İlerleme:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_uk.ts
+++ b/src/translations/libfm-qt_uk.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>Виконання</translation>
+        <source>Progress:</source>
+        <translation>Виконання:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_zh_CN.ts
+++ b/src/translations/libfm-qt_zh_CN.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>进度</translation>
+        <source>Progress:</source>
+        <translation>进度:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>

--- a/src/translations/libfm-qt_zh_TW.ts
+++ b/src/translations/libfm-qt_zh_TW.ts
@@ -164,8 +164,8 @@
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="75"/>
-        <source>Progress</source>
-        <translation>進度</translation>
+        <source>Progress:</source>
+        <translation>進度:</translation>
     </message>
     <message>
         <location filename="../file-operation-dialog.ui" line="95"/>


### PR DESCRIPTION
All labels that should have colons (per pointing to an input) had colons, except one.

**Steps:**
1. `designer6 $(find . -name "*.ui")` to check labels. Thankfully, there was only one label with a missing colon.
2. `grep ":</translation>" src/translations/*` to ensure the existing translations all use the ASCII colon.

The only differing language convention was French, with `<space>:` instead of `:`.

The `line="75"` in `<location filename="../file-operation-dialog.ui" line="75"/>` is the only thing that looks suspicious.