### PR TITLE
Try to stop or eject drive before ejecting volume from side-pane

### DIFF
--- a/src/mountoperation.cpp
+++ b/src/mountoperation.cpp
@@ -207,6 +207,24 @@ void MountOperation::onEjectVolumeFinished(GVolume* volume, GAsyncResult* res, Q
     delete pThis;
 }
 
+void MountOperation::onStopDriveFinished(GDrive* drive, GAsyncResult* res, QPointer<MountOperation>* pThis) {
+    if(*pThis) {
+        GError* error = nullptr;
+        g_drive_stop_finish(drive, res, &error);
+        (*pThis)->handleFinish(error);
+    }
+    delete pThis;
+}
+
+void MountOperation::onEjectDriveFinished(GDrive* drive, GAsyncResult* res, QPointer<MountOperation>* pThis) {
+    if(*pThis) {
+        GError* error = nullptr;
+        g_drive_eject_with_operation_finish(drive, res, &error);
+        (*pThis)->handleFinish(error);
+    }
+    delete pThis;
+}
+
 void MountOperation::onEjectFileFinished(GFile* file, GAsyncResult* res, QPointer<MountOperation>* pThis) {
     if(*pThis) {
         GError* error = nullptr;

--- a/src/mountoperation.h
+++ b/src/mountoperation.h
@@ -93,6 +93,21 @@ public:
             prepareUnmount(mnt);
             g_object_unref(mnt);
         }
+        // The current function is called when the volume can be ejected,
+        // but we first check if the drive can be stopped or ejected.
+        if(GDrive* drv = g_volume_get_drive(volume)) {
+            if(g_drive_can_stop(drv)) {
+                g_drive_stop(drv, G_MOUNT_UNMOUNT_NONE, op, cancellable_, (GAsyncReadyCallback)onStopDriveFinished, new QPointer<MountOperation>(this));
+                g_object_unref(drv);
+                return;
+            }
+            else if(g_drive_can_eject(drv)) {
+                g_drive_eject_with_operation(drv, G_MOUNT_UNMOUNT_NONE, op, cancellable_, (GAsyncReadyCallback)onEjectDriveFinished, new QPointer<MountOperation>(this));
+                g_object_unref(drv);
+                return;
+            }
+            g_object_unref(drv);
+        }
         g_volume_eject_with_operation(volume, G_MOUNT_UNMOUNT_NONE, op, cancellable_, (GAsyncReadyCallback)onEjectVolumeFinished, new QPointer<MountOperation>(this));
     }
 
@@ -163,6 +178,8 @@ private:
     static void onEjectMountFinished(GMount* mount, GAsyncResult* res, QPointer<MountOperation>* pThis);
     static void onEjectVolumeFinished(GVolume* volume, GAsyncResult* res, QPointer<MountOperation>* pThis);
     static void onEjectFileFinished(GFile* file, GAsyncResult* res, QPointer<MountOperation>* pThis);
+    static void onStopDriveFinished(GDrive* drive, GAsyncResult* res, QPointer<MountOperation>* pThis);
+    static void onEjectDriveFinished(GDrive* drive, GAsyncResult* res, QPointer<MountOperation>* pThis);
 
     void handleFinish(GError* error);
 


### PR DESCRIPTION
Lack of drive stopping/ejection caused USB sticks to remain powered after they were ejected by the app.

Closes https://github.com/lxqt/libfm-qt/issues/1048

NOTE 1: As far as I know, only USB sticks and optical media support ejection, in different senses. An external hard drive can only be unmounted, partition by partition.

NOTE 2: Please don't merge before 2.2.0 is released.