### PR TITLE
Added "Safely Remove" to side-pane context menu when possible

### DIFF
--- a/src/mountoperation.cpp
+++ b/src/mountoperation.cpp
@@ -207,6 +207,24 @@ void MountOperation::onEjectVolumeFinished(GVolume* volume, GAsyncResult* res, Q
     delete pThis;
 }
 
+void MountOperation::onStopDriveFinished(GDrive* drive, GAsyncResult* res, QPointer<MountOperation>* pThis) {
+    if(*pThis) {
+        GError* error = nullptr;
+        g_drive_stop_finish(drive, res, &error);
+        (*pThis)->handleFinish(error);
+    }
+    delete pThis;
+}
+
+void MountOperation::onEjectDriveFinished(GDrive* drive, GAsyncResult* res, QPointer<MountOperation>* pThis) {
+    if(*pThis) {
+        GError* error = nullptr;
+        g_drive_eject_with_operation_finish(drive, res, &error);
+        (*pThis)->handleFinish(error);
+    }
+    delete pThis;
+}
+
 void MountOperation::onEjectFileFinished(GFile* file, GAsyncResult* res, QPointer<MountOperation>* pThis) {
     if(*pThis) {
         GError* error = nullptr;

--- a/src/placesmodelitem.cpp
+++ b/src/placesmodelitem.cpp
@@ -150,6 +150,16 @@ bool PlacesModelVolumeItem::isMounted() {
     return mount != nullptr ? true : false;
 }
 
+bool PlacesModelVolumeItem::canSafelyRemove() {
+    if(GDrive* drv = g_volume_get_drive(volume_)) {
+        if(g_drive_can_stop(drv)) {
+            g_object_unref(drv);
+            return true;
+        }
+        g_object_unref(drv);
+    }
+    return false;
+}
 
 PlacesModelMountItem::PlacesModelMountItem(GMount* mount):
     PlacesModelItem(),

--- a/src/placesmodelitem.h
+++ b/src/placesmodelitem.h
@@ -92,6 +92,7 @@ public:
     bool canEject() {
         return g_volume_can_eject(volume_);
     }
+    bool canSafelyRemove();
     int type() const override {
         return Volume;
     }

--- a/src/placesview.cpp
+++ b/src/placesview.cpp
@@ -654,6 +654,11 @@ void PlacesView::contextMenuEvent(QContextMenuEvent* event) {
                 connect(action, &QAction::triggered, this, &PlacesView::onEjectVolume);
                 menu->addAction(action);
             }
+            else if(volumeItem->canSafelyRemove()) {
+                action = new PlacesModel::ItemAction(item->index(), tr("Safely Remove"), menu);
+                connect(action, &QAction::triggered, this, &PlacesView::onEjectVolume);
+                menu->addAction(action);
+            }
             // add a "Hide" action to the end
             CStrPtr uuid{g_volume_get_uuid(static_cast<PlacesModelVolumeItem*>(item)->volume())};
             if(uuid) {


### PR DESCRIPTION
This new item appears only if (`GIO` announces that) the drive is stoppable.

Also, when a volume can be ejected, the code first tries to stop or eject the *drive* instead, and only if unsuccessful, it tries to eject the volume itself.

Closes https://github.com/lxqt/libfm-qt/issues/1048