### PR TITLE
Add and make message more descriptive for emptying trash

### DIFF
--- a/src/fileoperation.cpp
+++ b/src/fileoperation.cpp
@@ -416,6 +416,28 @@ FileOperation* FileOperation::deleteFiles(Fm::FilePathList srcFiles, bool prompt
 }
 
 //static
+FileOperation* FileOperation::emptyTrashFiles(bool prompt, QWidget* parent) {
+
+    Fm::FilePathList srcFiles;
+    srcFiles.push_back(Fm::FilePath::fromUri("trash:///"));
+
+    if(prompt && !srcFiles.empty()) {
+        int result = QMessageBox::warning(parent ? parent->window() : nullptr,
+                                          tr("Confirm"),
+                                          tr("Do you want to empty the trash can?", nullptr, srcFiles.size()),
+                                          QMessageBox::Yes | QMessageBox::No,
+                                          QMessageBox::No);
+        if(result != QMessageBox::Yes) {
+            return nullptr;
+        }
+    }
+
+    FileOperation* op = new FileOperation(FileOperation::Delete, std::move(srcFiles), parent);
+    op->run();
+    return op;
+}
+
+//static
 FileOperation* FileOperation::trashFiles(Fm::FilePathList srcFiles, bool prompt, QWidget* parent) {
     if(prompt && !srcFiles.empty()) {
         int result = QMessageBox::warning(parent ? parent->window() : nullptr,

--- a/src/fileoperation.h
+++ b/src/fileoperation.h
@@ -117,9 +117,11 @@ public:
         return symlinkFiles(FilePathList{std::move(srcFile)}, FilePathList{std::move(destFile)}, parent);
     }
 
-    static FileOperation* deleteFiles(Fm::FilePathList srcFiles, bool promp = true, QWidget* parent = nullptr);
+    static FileOperation* deleteFiles(Fm::FilePathList srcFiles, bool prompt = true, QWidget* parent = nullptr);
 
-    static FileOperation* trashFiles(Fm::FilePathList srcFiles, bool promp = true, QWidget* parent = nullptr);
+    static FileOperation* emptyTrashFiles(bool prompt = true, QWidget* parent = nullptr);
+
+    static FileOperation* trashFiles(Fm::FilePathList srcFiles, bool prompt = true, QWidget* parent = nullptr);
 
     static FileOperation* unTrashFiles(Fm::FilePathList srcFiles, QWidget* parent = nullptr);
 

--- a/src/foldermenu.cpp
+++ b/src/foldermenu.cpp
@@ -58,9 +58,7 @@ FolderMenu::FolderMenu(FolderView* view, QWidget* parent):
                 auto trashAction = new QAction(tr("Empty Trash"), this);
                 addAction(trashAction);
                 connect(trashAction, &QAction::triggered, []() {
-                    Fm::FilePathList files;
-                    files.push_back(Fm::FilePath::fromUri("trash:///"));
-                    Fm::FileOperation::deleteFiles(std::move(files), true);
+                    Fm::FileOperation::emptyTrashFiles(true);
                 });
                 addSeparator();
             }

--- a/src/placesview.cpp
+++ b/src/placesview.cpp
@@ -396,9 +396,7 @@ void PlacesView::onEmptyTrash() {
     // The main event loop might be blocked by a question message box and
     // cause a crash with Qt6 if the current slot does not return first.
     QTimer::singleShot(0, this, [] {
-        Fm::FilePathList files;
-        files.push_back(Fm::FilePath::fromUri("trash:///"));
-        Fm::FileOperation::deleteFiles(std::move(files), true);
+        Fm::FileOperation::emptyTrashFiles(true);
     });
 }
 


### PR DESCRIPTION
Previously the wrong message was prompted - "Do you want to delete the selected file(s)?"

Extra `FileOperation::` function was warranted because `FileOperation::deleteFiles` shouldn't be passed a message string.

Todo: Use the function in PCManFM-Qt desktop; it's coded separately there.