### PR TITLE
Small UX improvement to emptying Trash inside folder

### DIFF
--- a/src/foldermenu.cpp
+++ b/src/foldermenu.cpp
@@ -54,16 +54,15 @@ FolderMenu::FolderMenu(FolderView* view, QWidget* parent):
     }
     if(insideTrash) {
         if(auto folder = view_->folder()) {
-            if(!folder->isEmpty()) {
-                auto trashAction = new QAction(tr("Empty Trash"), this);
-                addAction(trashAction);
-                connect(trashAction, &QAction::triggered, []() {
-                    Fm::FilePathList files;
-                    files.push_back(Fm::FilePath::fromUri("trash:///"));
-                    Fm::FileOperation::deleteFiles(std::move(files), true);
-                });
-                addSeparator();
-            }
+            auto trashAction = new QAction(tr("Empty Trash"), this);
+            trashAction->setEnabled(!folder->isEmpty());
+            addAction(trashAction);
+            connect(trashAction, &QAction::triggered, []() {
+                Fm::FilePathList files;
+                files.push_back(Fm::FilePath::fromUri("trash:///"));
+                Fm::FileOperation::deleteFiles(std::move(files), true);
+            });
+            addSeparator();
         }
     }
     else if (!insideSearch) {


### PR DESCRIPTION
Previously the menu action for emptying, inside the `trash:///` folder, disappeared when there was nothing to empty.

This makes the menu consistent with Desktop and 'Places' menus, which instead greyed the action. It also in my opinion is better UX.

**To test**
1. PCManFM-Qt → Places → Trash → Right click
2. PCManFM-Qt Desktop → Trash → Right click
3. PCManFM-Qt `trash:///` → Right click