### PR TITLE
cmake: fix build with Qt 6.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,10 @@ set(QT_MINIMUM_VERSION "6.6.0")
 find_package(Qt6Widgets "${QT_MINIMUM_VERSION}" REQUIRED)
 find_package(Qt6LinguistTools "${QT_MINIMUM_VERSION}" REQUIRED)
 
+if (Qt6Gui_VERSION VERSION_GREATER_EQUAL "6.10.0")
+    find_package(Qt6GuiPrivate REQUIRED)
+endif()
+
 find_package(lxqt2-build-tools "${LXQTBT_MINIMUM_VERSION}" REQUIRED)
 find_package(GLIB "${GLIB_MINIMUM_VERSION}" REQUIRED COMPONENTS gio gio-unix gobject gthread)
 find_package(MenuCache "${LIBMENUCACHE_MINIMUM_VERSION}" REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -132,14 +132,17 @@ install(EXPORT
 )
 
 target_link_libraries(${LIBFM_QT_LIBRARY_NAME}
-    Qt6::Widgets
-    ${GLIB_LIBRARIES}
-    ${GLIB_GIO_LIBRARIES}
-    ${GLIB_GOBJECT_LIBRARIES}
-    ${GLIB_GTHREAD_LIBRARIES}
-    ${MENUCACHE_LIBRARIES}
-    ${XCB_LIBRARIES}
-    ${EXIF_LIBRARIES}
+    PRIVATE
+        Qt6::GuiPrivate
+    PUBLIC
+        Qt6::Widgets
+        ${GLIB_LIBRARIES}
+        ${GLIB_GIO_LIBRARIES}
+        ${GLIB_GOBJECT_LIBRARIES}
+        ${GLIB_GTHREAD_LIBRARIES}
+        ${MENUCACHE_LIBRARIES}
+        ${XCB_LIBRARIES}
+        ${EXIF_LIBRARIES}
 )
 
 # set libtool soname


### PR DESCRIPTION
The 'Qt6FooPrivate' targets have been split into separate CMake files
in Qt 6.9, and require a 'find_package(Qt6FooPrivate)' call starting
with Qt 6.10.

See also: https://bugreports.qt.io/browse/QTBUG-87776
