### PR TITLE
Assign rename file dialog to the parent window

### DIFF
--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -534,7 +534,7 @@ void FileMenu::onRenameTriggered() {
         }
     }
     for(auto& info: files_) {
-        if(!Fm::renameFile(info, nullptr)) {
+        if(!Fm::renameFile(info, parentWidget())) {
             break;
         }
     }


### PR DESCRIPTION
This ensures that the dialog is attached to the main window.