### PR TITLE
Assign color and font dialogs to the parent window

### DIFF
--- a/src/colorbutton.cpp
+++ b/src/colorbutton.cpp
@@ -32,7 +32,7 @@ ColorButton::~ColorButton() {
 }
 
 void ColorButton::onClicked() {
-    QColorDialog dlg(color_);
+    QColorDialog dlg(color_, this);
     if(dlg.exec() == QDialog::Accepted) {
         setColor(dlg.selectedColor());
     }

--- a/src/fontbutton.cpp
+++ b/src/fontbutton.cpp
@@ -32,7 +32,7 @@ FontButton::~FontButton() {
 }
 
 void FontButton::onClicked() {
-    QFontDialog dlg(font_);
+    QFontDialog dlg(font_, this);
     if(dlg.exec() == QDialog::Accepted) {
         setFont(dlg.selectedFont());
     }


### PR DESCRIPTION
This ensures that the dialogs are attached to the main window.

Can be tested on the desktop preferences window (`pcmanfm-qt --desktop-pref=general`).