### PR TITLE
Make dialogs as modal only for the window

### DIFF
--- a/src/colorbutton.cpp
+++ b/src/colorbutton.cpp
@@ -33,6 +33,7 @@ ColorButton::~ColorButton() {
 
 void ColorButton::onClicked() {
     QColorDialog dlg(color_, this);
+    dlg.setWindowModality(Qt::WindowModal);
     if(dlg.exec() == QDialog::Accepted) {
         setColor(dlg.selectedColor());
     }

--- a/src/fileoperationdialog.cpp
+++ b/src/fileoperationdialog.cpp
@@ -109,6 +109,7 @@ FileOperationJob::FileExistsAction FileOperationDialog::askRename(const FileInfo
        || (defaultOption == RenameDialog::ActionOverwrite
            && src.path() == dest.path())) {
         RenameDialog dlg(src, dest, this);
+        dlg.setWindowModality(Qt::WindowModal);
         dlg.exec();
         switch(dlg.action()) {
         case RenameDialog::ActionOverwrite:

--- a/src/fontbutton.cpp
+++ b/src/fontbutton.cpp
@@ -33,6 +33,7 @@ FontButton::~FontButton() {
 
 void FontButton::onClicked() {
     QFontDialog dlg(font_, this);
+    dlg.setWindowModality(Qt::WindowModal);
     if(dlg.exec() == QDialog::Accepted) {
         setFont(dlg.selectedFont());
     }

--- a/src/mountoperation.cpp
+++ b/src/mountoperation.cpp
@@ -118,6 +118,7 @@ void MountOperation::onAskPassword(GMountOperation* /*_op*/, gchar* message, gch
         // The mount is NOT done by g_volume_mount();
         // it is safe to show the password dialog (see below).
         MountOperationPasswordDialog dlg(pThis, flags);
+        dlg.setWindowModality(Qt::WindowModal);
         dlg.setMessage(QString::fromUtf8(message));
         dlg.setDefaultUser(QString::fromUtf8(default_user));
         dlg.setDefaultDomain(QString::fromUtf8(default_domain));
@@ -172,6 +173,7 @@ void MountOperation::onAskPassword(GMountOperation* /*_op*/, gchar* message, gch
 void MountOperation::onAskQuestion(GMountOperation* /*_op*/, gchar* message, GStrv choices, MountOperation* pThis) {
     qDebug("ask question");
     MountOperationQuestionDialog dialog(pThis, message, choices);
+    dialog.setWindowModality(Qt::WindowModal);
     dialog.exec();
 }
 

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -167,6 +167,7 @@ bool changeFileName(const Fm::FilePath& filePath, const QString& newName, QWidge
 
 bool renameFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent) {
     FilenameDialog dlg(parent ? parent->window() : nullptr);
+    dlg.setWindowModality(Qt::WindowModal);
     dlg.setWindowTitle(QObject::tr("Rename File"));
     dlg.setLabelText(QObject::tr("Please enter a new name:"));
     // NOTE: "Edit name" seems the best way to handle non-UTF8 filename encoding.


### PR DESCRIPTION
Without this, the dialogs block all opened windows of the application, not just the parent window.