### PR TITLE
Strange sorting on cyrillic locale

### DIFF
--- a/src/proxyfoldermodel.cpp
+++ b/src/proxyfoldermodel.cpp
@@ -40,6 +40,7 @@ ProxyFolderModel::ProxyFolderModel(QObject* parent):
     setSortCaseSensitivity(Qt::CaseInsensitive);
 
     collator_.setNumericMode(true);
+    collator_.setLocale(QLocale::AnyLanguage);
 }
 
 ProxyFolderModel::~ProxyFolderModel() {


### PR DESCRIPTION
On a system with cyrillic locale(i tested with ukrainian and russian ones) file names sorting is very strange.
It places cyrillic names before latin ones, like
__file
123
567
абв
где
abc
defgh
I cannot remember any program with such sorting, and it is couter intuitive because any non-latin characters have higher codes.
The bug is very annoying