### PR TITLE
Enable C EXTENSIONS for core

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_C_EXTENSIONS ON)
+
 set(libfm_core_SRCS
     # gio gvfs implementations
     core/vfs/fm-file.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(CMAKE_C_EXTENSIONS ON)
 
+add_compile_options("$<$<CXX_COMPILER_ID:Clang>:-Wno-c2y-extensions>")
+
 set(libfm_core_SRCS
     # gio gvfs implementations
     core/vfs/fm-file.c


### PR DESCRIPTION
Needed after https://github.com/lxqt/lxqt-build-tools/pull/113.
As a "side effect" it also fixes some const related warnings.
