### PR TITLE
Made tree view header unmovable

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -349,6 +349,8 @@ FolderViewTreeView::FolderViewTreeView(QWidget* parent):
 
     header()->setSectionResizeMode(QHeaderView::Interactive);
     header()->setStretchLastSection(true);
+    // movable sections are not worth the needed extra codes
+    header()->setSectionsMovable(false);
 
     // get the new width if the section is resized by user
     connect(header(), &QHeaderView::sectionResized, [this](int logicalIndex, int/* oldSize*/, int newSize) {


### PR DESCRIPTION
The supposed benefit of having a movable header isn't worth the extra needed code.

NOTE: I don't have time for hot discussions about how "important" movable headers are. If you think they're important, please tell why, instead of saying "this or than FM has it", "I like it", etc. I'll wait for a convincing argument for a while.