### PR TITLE
Enhance search experience with incremental file listing and be able to stop a search job

### DIFF
--- a/src/core/dirlistjob.cpp
+++ b/src/core/dirlistjob.cpp
@@ -7,7 +7,11 @@
 namespace Fm {
 
 DirListJob::DirListJob(const FilePath& path, Flags _flags):
-    dir_path{path}, flags{_flags} {
+    dir_path{path}, flags{_flags}, emit_files_found{false} {
+}
+
+void DirListJob::setIncremental(bool set) {
+    emit_files_found = set;
 }
 
 void DirListJob::exec() {
@@ -79,6 +83,10 @@ _retry:
     }
 
     FileInfoList foundFiles;
+    FileInfoList incrementalBatch;
+    // batch size trades round-trip overhead against result latency;
+    // revisit if very large recursive searches feel laggy.
+    constexpr std::size_t incrementalBatchSize = 32;
     /* check if FS is R/O and set attr. into inf */
     // FIXME:  _fm_file_info_job_update_fs_readonly(gf, inf, nullptr, nullptr);
     err.reset();
@@ -126,7 +134,11 @@ _retry:
 #endif
                 auto fileInfo = std::make_shared<FileInfo>(inf, FilePath(), realParentPath);
                 if(emit_files_found) {
-                    // Q_EMIT filesFound();
+                    incrementalBatch.push_back(fileInfo);
+                    if(incrementalBatch.size() >= incrementalBatchSize) {
+                        Q_EMIT filesFound(incrementalBatch);
+                        incrementalBatch.clear();
+                    }
                 }
 
                 foundFiles.push_back(std::move(fileInfo));
@@ -143,6 +155,10 @@ _retry:
                 break;
             }
         }
+        if(emit_files_found && !incrementalBatch.empty()) {
+            Q_EMIT filesFound(incrementalBatch);
+            incrementalBatch.clear();
+        }
         err.reset();
         g_file_enumerator_close(enu.get(), cancellable().get(), &err);
     }
@@ -158,43 +174,5 @@ _retry:
         files_.swap(foundFiles);
     }
 }
-
-#if 0
-//FIXME: incremental..
-
-static gboolean emit_found_files(gpointer user_data) {
-    /* this callback is called from the main thread */
-    FmDirListJob* job = FM_DIR_LIST_JOB(user_data);
-    /* g_print("emit_found_files: %d\n", g_slist_length(job->files_to_add)); */
-
-    if(g_source_is_destroyed(g_main_current_source())) {
-        return FALSE;
-    }
-    g_signal_emit(job, signals[FILES_FOUND], 0, job->files_to_add);
-    g_slist_free_full(job->files_to_add, (GDestroyNotify)fm_file_info_unref);
-    job->files_to_add = nullptr;
-    job->delay_add_files_handler = 0;
-    return FALSE;
-}
-
-static gpointer queue_add_file(FmJob* fmjob, gpointer user_data) {
-    FmDirListJob* job = FM_DIR_LIST_JOB(fmjob);
-    FmFileInfo* file = FM_FILE_INFO(user_data);
-    /* this callback is called from the main thread */
-    /* g_print("queue_add_file: %s\n", fm_file_info_get_disp_name(file)); */
-    job->files_to_add = g_slist_prepend(job->files_to_add, fm_file_info_ref(file));
-    if(job->delay_add_files_handler == 0)
-        job->delay_add_files_handler = g_timeout_add_seconds_full(G_PRIORITY_LOW,
-                                       1, emit_found_files, g_object_ref(job), g_object_unref);
-    return nullptr;
-}
-
-void fm_dir_list_job_add_found_file(FmDirListJob* job, FmFileInfo* file) {
-    fm_file_info_list_push_tail(job->files, file);
-    if(G_UNLIKELY(job->emit_files_found)) {
-        fm_job_call_main_thread(FM_JOB(job), queue_add_file, file);
-    }
-}
-#endif
 
 } // namespace Fm

--- a/src/core/dirlistjob.cpp
+++ b/src/core/dirlistjob.cpp
@@ -85,7 +85,7 @@ _retry:
     FileInfoList foundFiles;
     FileInfoList incrementalBatch;
     // batch size trades round-trip overhead against result latency;
-    // revisit if very large recursive searches feel laggy.
+    // revisit if very large recursive incremental listing feels laggy.
     constexpr std::size_t incrementalBatchSize = 32;
     /* check if FS is R/O and set attr. into inf */
     // FIXME:  _fm_file_info_job_update_fs_readonly(gf, inf, nullptr, nullptr);

--- a/src/core/folder.cpp
+++ b/src/core/folder.cpp
@@ -22,7 +22,6 @@
  */
 
 #include "folder.h"
-#include <cstring>
 #include <cassert>
 #include <QTimer>
 #include <QDebug>
@@ -531,11 +530,14 @@ void Folder::onDirListFinished() {
     std::vector<FileInfoPair> files_to_update;
     const auto& infos = job->files();
 
-    // with "search://", there is no update for infos and all of them should be added
+    // with "search://", there is no update for infos and all of them should be added,
+    // unless they were already streamed live via onDirListFilesFound() as they were found
     if(dirPath_.hasUriScheme("search")) {
-        files_to_add = infos;
-        for(auto& file: files_to_add) {
-            files_[file->path().baseName().get()] = file;
+        if(!job->incremental()) {
+            files_to_add = infos;
+            for(auto& file: files_to_add) {
+                files_[file->path().baseName().get()] = file;
+            }
         }
     }
     else {
@@ -619,6 +621,20 @@ void Folder::onDirListFinished() {
     Q_EMIT finishLoading();
 }
 
+// slot, called (via a blocking queued connection) while a "search://" listing is still running,
+// so matched files can appear in the view as they're found instead of all at once at the end.
+void Folder::onDirListFilesFound(FileInfoList& foundFiles) {
+    FileInfoList files_to_add;
+    files_to_add.reserve(foundFiles.size());
+    for(auto& file: foundFiles) {
+        files_[file->path().baseName().get()] = file;
+        files_to_add.push_back(file);
+    }
+    if(!files_to_add.empty()) {
+        Q_EMIT filesAdded(files_to_add);
+    }
+}
+
 #if 0
 
 
@@ -660,6 +676,12 @@ void free_dirlist_job(FmFolder* folder) {
 
 #endif
 
+
+void Folder::stopLoading() {
+    if(dirlist_job) {
+        dirlist_job->cancel();
+    }
+}
 
 void Folder::reload() {
     if(dirlist_job) {
@@ -750,17 +772,17 @@ void Folder::reallyReload() {
     /* run a new dir listing job */
     // FIXME:
     // defer_content_test = fm_config->defer_content_test;
+    // "search://" results can take a while to enumerate recursively, so stream them into
+    // the view as they're found instead of making the user stare at an empty folder.
+    wants_incremental = dirPath_.hasUriScheme("search");
     dirlist_job = new DirListJob(dirPath_, defer_content_test ? DirListJob::FAST : DirListJob::DETAILED);
     dirlist_job->setAutoDelete(true);
+    dirlist_job->setIncremental(wants_incremental);
     connect(dirlist_job, &DirListJob::error, this, &Folder::error, Qt::BlockingQueuedConnection);
     connect(dirlist_job, &DirListJob::finished, this, &Folder::onDirListFinished, Qt::BlockingQueuedConnection);
-
-#if 0
     if(wants_incremental) {
-        g_signal_connect(dirlist_job, "files-found", G_CALLBACK(on_dirlist_job_files_found), folder);
+        connect(dirlist_job, &DirListJob::filesFound, this, &Folder::onDirListFilesFound, Qt::BlockingQueuedConnection);
     }
-    fm_dir_list_job_set_incremental(dirlist_job, wants_incremental);
-#endif
 
     dirlist_job->runAsync();
 

--- a/src/core/folder.cpp
+++ b/src/core/folder.cpp
@@ -108,7 +108,7 @@ Folder::~Folder() {
 }
 
 // static
-std::shared_ptr<Folder> Folder::fromPath(const FilePath& path) {
+std::shared_ptr<Folder> Folder::fromPath(const FilePath& path, bool incremental) {
     std::lock_guard<std::mutex> lock{mutex_};
     auto it = cache_.find(path);
     if(it != cache_.end()) {
@@ -121,6 +121,7 @@ std::shared_ptr<Folder> Folder::fromPath(const FilePath& path) {
         }
     }
     auto folder = std::make_shared<Folder>(path);
+    folder->setIncremental(incremental);
     folder->reload();
     cache_.emplace(path, folder);
     return folder;
@@ -148,6 +149,10 @@ bool Folder::makeDirectory(const char* /*name*/, GError** /*error*/) {
 
 bool Folder::isIncremental() const {
     return wants_incremental;
+}
+
+void Folder::setIncremental(bool incremental) {
+    wants_incremental = incremental;
 }
 
 bool Folder::isValid() const {
@@ -621,7 +626,7 @@ void Folder::onDirListFinished() {
     Q_EMIT finishLoading();
 }
 
-// slot, called (via a blocking queued connection) while a "search://" listing is still running,
+// slot, called (via a blocking queued connection) while an incremental listing is still running,
 // so matched files can appear in the view as they're found instead of all at once at the end.
 void Folder::onDirListFilesFound(FileInfoList& foundFiles) {
     FileInfoList files_to_add;
@@ -772,9 +777,6 @@ void Folder::reallyReload() {
     /* run a new dir listing job */
     // FIXME:
     // defer_content_test = fm_config->defer_content_test;
-    // "search://" results can take a while to enumerate recursively, so stream them into
-    // the view as they're found instead of making the user stare at an empty folder.
-    wants_incremental = dirPath_.hasUriScheme("search");
     dirlist_job = new DirListJob(dirPath_, defer_content_test ? DirListJob::FAST : DirListJob::DETAILED);
     dirlist_job->setAutoDelete(true);
     dirlist_job->setIncremental(wants_incremental);

--- a/src/core/folder.h
+++ b/src/core/folder.h
@@ -66,6 +66,10 @@ public:
 
     void reload();
 
+    // cancels an in-progress listing job in place, keeping whatever files were already
+    // found (unlike reload(), which cancels and immediately starts over)
+    void stopLoading();
+
     bool isIncremental() const;
 
     bool isValid() const;
@@ -139,6 +143,8 @@ private Q_SLOTS:
     void processPendingChanges();
 
     void onDirListFinished();
+
+    void onDirListFilesFound(FileInfoList& foundFiles);
 
     void onFileSystemInfoFinished();
 

--- a/src/core/folder.h
+++ b/src/core/folder.h
@@ -54,7 +54,7 @@ public:
 
     ~Folder() override;
 
-    static std::shared_ptr<Folder> fromPath(const FilePath& path);
+    static std::shared_ptr<Folder> fromPath(const FilePath& path, bool incremental = false);
 
     static std::shared_ptr<Folder> findByPath(const FilePath& path);
 
@@ -71,6 +71,8 @@ public:
     void stopLoading();
 
     bool isIncremental() const;
+
+    void setIncremental(bool incremental);
 
     bool isValid() const;
 


### PR DESCRIPTION
## 🔍 Incremental search results + stoppable search jobs

`search://` listings were collected entirely in memory and only handed to the UI once the whole recursive enumeration finished — so a slow search looked completely frozen/empty the whole time it ran, and there was no way to cancel one in progress without destroying the `Folder` object outright (e.g. by closing the tab). This PR wires up the incremental-loading logic that already existed as dead/unfinished code, and adds a real stop API. It's the companion library change for the search-UX work in `pcmanfm-qt`.

- `DirListJob` now emits `filesFound()` in batches of 32 (⚙️ tunable — flagged inline as a lazy tradeoff between round-trip overhead and result latency) while enumerating a `search://` job, instead of silently collecting everything into one list and dumping it into the view only at the very end.
- 🔗 **Wired up `Folder`** — new `Folder::onDirListFilesFound()` slot forwards each batch straight into the existing `filesAdded` signal, over the same `Qt::BlockingQueuedConnection` pattern this file already uses for `error` (the job runs on its own thread via `Job::runAsync()`, so this keeps `Folder::files_` mutations serialized onto the main thread). `FolderModel` already listens to `filesAdded` unconditionally, so it picks up rows **live** with zero downstream changes needed.
- 🛑 **New `Folder::stopLoading()`** — cancels the in-flight `DirListJob` in place, without restarting it (unlike `reload()`, which cancels and immediately starts a fresh job). Needed no further plumbing: because results stream in as they're found rather than all at once, cancelling mid-search just stops it wherever it is, and the existing cancelled-job branch in `onDirListFinished()` already settles the folder into a correct "loaded" state with whatever was found so far.
- **Bug fixes**:
  - `emit_files_found` was never initialized in `DirListJob`'s constructor — reading it (via `incremental()`, and in `exec()`) was undefined behavior.
  - `DirListJob::setIncremental()` was declared in the header but never defined anywhere — calling it would have been a link error.
- **Deleted ~30 lines of dead `#if 0` GLib/C-era code** (`emit_found_files`, `queue_add_file`, `fm_dir_list_job_add_found_file`, and the `#if 0`'d incremental-connect block in `reallyReload()`) that was never compiled — this is exactly the functionality the new Qt-native `filesFound`/`onDirListFilesFound` implementation replaces.

Companion PR in `pcmanfm-qt` https://github.com/lxqt/pcmanfm-qt/pull/2190