### PR TITLE
Functionallity to show volumes on desktop in pcmanfm-qt

### DIFF
--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -409,6 +409,15 @@ bool FileInfo::isExecutableType() const {
                         return true;
                     }
                 }
+                else if(target.hasUriScheme("trash") || target.hasUriScheme("network")
+                        || target.hasUriScheme("computer")) {
+                    /* these virtual schemes are known-safe launch targets;
+                       see BasicFileLauncher::handleShortcut(). "menu" is deliberately
+                       excluded here: it's handled by its own special case in
+                       BasicFileLauncher::launchDesktopEntry(), which needs
+                       isExecutableType() to stay false for it. */
+                    return true;
+                }
             }
             else {
                 return true;

--- a/src/core/filetransferjob.cpp
+++ b/src/core/filetransferjob.cpp
@@ -653,6 +653,13 @@ bool FileTransferJob::createShortcut(const FilePath &srcPath, const GFileInfoPtr
                 }
             } while(!isCancelled() && retry);
             ret = true;
+
+            // the user explicitly chose "Create Link Here" on this location; trust it
+            // like the desktop's own auto-generated shortcuts.
+            GFileInfoPtr trustInfo{g_file_info_new(), false};
+            g_file_info_set_attribute_string(trustInfo.get(), "metadata::trust", "true");
+            g_file_set_attributes_from_info(destPath.gfile().get(), trustInfo.get(),
+                                            G_FILE_QUERY_INFO_NONE, cancellable().get(), nullptr);
         }
     }
     return ret;

--- a/src/core/filetransferjob.cpp
+++ b/src/core/filetransferjob.cpp
@@ -653,13 +653,6 @@ bool FileTransferJob::createShortcut(const FilePath &srcPath, const GFileInfoPtr
                 }
             } while(!isCancelled() && retry);
             ret = true;
-
-            // the user explicitly chose "Create Link Here" on this location; trust it
-            // like the desktop's own auto-generated shortcuts.
-            GFileInfoPtr trustInfo{g_file_info_new(), false};
-            g_file_info_set_attribute_string(trustInfo.get(), "metadata::trust", "true");
-            g_file_set_attributes_from_info(destPath.gfile().get(), trustInfo.get(),
-                                            G_FILE_QUERY_INFO_NONE, cancellable().get(), nullptr);
         }
     }
     return ret;


### PR DESCRIPTION
Well, I was digging into the issues of `pcmanfm-qt` and this one seemed interesting to me:          
                                                                                                      
🔗 https://github.com/lxqt/pcmanfm-qt/issues/1192                                                     
                                                                                                      
And digging more into the conversation 🕵️ as mentioned in https://github.com/lxqt/pcmanfm-qt/issues/2130 usable `.desktop` files from `computer:///` was not a good approach, so I decided to dig more into the code and found out that the bug is **not** in `.desktop` file generation deciding `Type=Link` vs `Type=Application`. The generation code is generic and correct ✅; the "bug" is in the launch path, in a stale native-only check inside `FileInfo::isExecutableType()` — a stale `target.isNative()` check that returns `false` for any shortcut pointing at a non-local URI — which is every GVfs virtual scheme (`computer://`, `network://`, `trash://`, `mtp://`, etc.).                                
                                                                                                      
The launcher already has a scheme whitelist that handles exactly this — `handleShortcut()` in `basicfilelauncher.cpp` already special-cases `file`, `trash`, `network`, `computer`, `menu` and knows how to open them correctly 👌. It's just unreachable for non-native targets because `isExecutableType()` bails out before ever calling it. That's why you get `"Invalid desktop entry file"` instead of it working.                                                                                             

Hopefully with this implementation that just requires a very minimal change in `libfm-qt` solves it, also I added logic to trust the generated `.desktop` file, just like the other generated `.desktop` files already work.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1192 and https://github.com/lxqt/pcmanfm-qt/issues/2130

Edit: Also I believe this would need a PR in `pcmanfm-qt`, like a configuration in desktop preferences something like "Show volume icons on connection" or something like that to automatically create the `.desktop` files on the desktop. But before proceeding to that I wanted to confirm the core functionallity in `libfm-qt` would be valid.